### PR TITLE
Fix YtdlpInfo entries handling

### DIFF
--- a/src/anypod/ytdlp_wrapper/ytdlp_core.py
+++ b/src/anypod/ytdlp_wrapper/ytdlp_core.py
@@ -109,15 +109,22 @@ class YtdlpInfo:
         raw_entries = self.get("entries", list[dict[str, Any] | None])  # type: ignore
         if raw_entries is None:
             return None
+
         entries: list[YtdlpInfo | None] = []
         for entry in raw_entries:  # type: ignore
+            if entry is None:
+                entries.append(None)
+                continue
+
             if not isinstance(entry, dict):
                 raise YtdlpFieldInvalidError(
                     field_name="entries",
                     expected_type=dict,
                     actual_value=entry,  # type: ignore
                 )
-            entries.append(YtdlpInfo(entry)) if entry else None  # type: ignore
+
+            entries.append(YtdlpInfo(entry))
+
         return entries
 
 

--- a/src/anypod/ytdlp_wrapper/ytdlp_core.py
+++ b/src/anypod/ytdlp_wrapper/ytdlp_core.py
@@ -116,7 +116,8 @@ class YtdlpInfo:
                 entries.append(None)
                 continue
 
-            if not isinstance(entry, dict):
+            # validate entry type at runtime
+            if not isinstance(entry, dict):  # pyright: ignore[reportUnnecessaryIsInstance]
                 raise YtdlpFieldInvalidError(
                     field_name="entries",
                     expected_type=dict,

--- a/tests/anypod/ytdlp_wrapper/test_ytdlp_info.py
+++ b/tests/anypod/ytdlp_wrapper/test_ytdlp_info.py
@@ -1,0 +1,39 @@
+"""Unit tests for ``YtdlpInfo`` utility methods."""
+
+import pytest
+
+from anypod.exceptions import YtdlpFieldInvalidError
+from anypod.ytdlp_wrapper.ytdlp_core import YtdlpInfo
+
+
+@pytest.mark.unit
+def test_entries_returns_none_when_no_entries():
+    """If ``entries`` field is missing, ``None`` is returned."""
+    info = YtdlpInfo({})
+    assert info.entries() is None
+
+
+@pytest.mark.unit
+def test_entries_handles_none_entries_and_dicts():
+    """``entries`` should return ``YtdlpInfo`` instances while preserving ``None``."""
+    info_dict = {"entries": [
+        {"id": "1"},
+        None,
+        {"id": "2"},
+    ]}
+    info = YtdlpInfo(info_dict)
+    entries = info.entries()
+    assert entries is not None
+    assert len(entries) == 3
+    assert isinstance(entries[0], YtdlpInfo)
+    assert entries[1] is None
+    assert isinstance(entries[2], YtdlpInfo)
+
+
+@pytest.mark.unit
+def test_entries_invalid_entry_type_raises():
+    """Non-dict, non-``None`` entries should raise ``YtdlpFieldInvalidError``."""
+    info_dict = {"entries": ["bad"]}
+    info = YtdlpInfo(info_dict)
+    with pytest.raises(YtdlpFieldInvalidError):
+        info.entries()

--- a/tests/anypod/ytdlp_wrapper/test_ytdlp_info.py
+++ b/tests/anypod/ytdlp_wrapper/test_ytdlp_info.py
@@ -16,11 +16,13 @@ def test_entries_returns_none_when_no_entries():
 @pytest.mark.unit
 def test_entries_handles_none_entries_and_dicts():
     """``entries`` should return ``YtdlpInfo`` instances while preserving ``None``."""
-    info_dict = {"entries": [
-        {"id": "1"},
-        None,
-        {"id": "2"},
-    ]}
+    info_dict = {
+        "entries": [
+            {"id": "1"},
+            None,
+            {"id": "2"},
+        ]
+    }
     info = YtdlpInfo(info_dict)
     entries = info.entries()
     assert entries is not None


### PR DESCRIPTION
## Summary
- handle `None` entries in `YtdlpInfo.entries`
- add tests for `YtdlpInfo.entries`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f3bf68188832aa065903f60bbbb1d