### PR TITLE
Implement unified path manager

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,9 +80,10 @@ feeds:
 - Keep functions under 50 lines and focused on single responsibilities
 - Scope `try` blocks tightly around specific statements that may raise exceptions
 - Bias towards wrapping and re-raising exceptions to the highest possible location
+- Exception messages should not include variable data - use existing exception parameters/attributes instead
 
-### Documentation Requirements
-All functions, methods, classes, and files require Google-style docstrings:
+### Docstring Guidelines
+- All functions, methods, classes, and files require Google-style docstrings:
 
 ```python
 def fetch_metadata(
@@ -105,39 +106,4 @@ def fetch_metadata(
     """
 ```
 
-## Testing Guidelines
-
-### Test Structure and Organization
-- Tests mirror source structure in `/tests/anypod/`
-- Integration tests in `/tests/integration/` with `integration_test_` prefix - run with `--integration` flag
-- Add `# pyright: reportPrivateUsage=false` to test files for protected method access
-- Use pytest markers: either `@pytest.mark.unit` or `@pytest.mark.integration` for all tests
-- Import packages directly (e.g., `from anypod.db import Database`) not `from src.anypod`
-
-### Test Writing Patterns
-- Use Arrange-Act-Assert pattern without explicit comments
-- Descriptive test names that describe behavior
-- One assertion per test when possible
-- Test both success and failure paths
-- Add descriptive messages to non-obvious assertions
-- Use `# type: ignore` for private method access complaints
-
-### Test Execution
-```bash
-# Unit tests only
-uv run pytest
-
-# Include integration tests
-uv run pytest --integration
-
-# With coverage
-uv run pytest --cov=src --cov-report=html
-```
-
-### Key Testing Rules
-- Mock at appropriate levels using `pytest-mock`
-- Don't mock external libraries you don't own
-- Avoid string checks on error messages
-- Keep tests fast and independent
-- Use fixtures in `conftest.py` for shared setup
-- Aim for meaningful coverage, not 100% blindly
+- When writing docstrings, never write one for __init__ fns, since this should be covered by the class level docstring

--- a/DESIGN_DOC.md
+++ b/DESIGN_DOC.md
@@ -378,6 +378,7 @@ This resolution logic aims to simplify configuration for the end-user, as they c
 * Transcoding fallback (ffmpeg) for non-MP4/M4A sources
 * OAuth device-flow
 * Prometheus `/metrics`
+* Consider restricting feed_id and download_id in `PathManager` to alphanumeric characters only (plus maybe hyphens/underscores) to avoid potential filesystem and URL encoding issues
 * Support transcripts/auto-generated (whisper can natively output .srt files)
   * > I'm a podcast author, how can I add transcripts to my show?
     > In order for Pocket Casts to discover transcripts for an episode and offer them within the app, the podcast feed must include the <podcast:transcript> element and the transcript must be in one of the following formats: VTT, SRT, PodcastIndex JSON, or HTML.

--- a/TASK_LIST.md
+++ b/TASK_LIST.md
@@ -223,13 +223,23 @@ This section details the components that manage the lifecycle of downloads, from
 - [x] Determine if a [read/write lock](https://pypi.org/project/readerwriterlock/) for in-memory feed XML cache is needed for concurrency
 - [x] add new fields to Download
   - this will also involve potentially changing how i update values, since some (like title) might get changed down the line. so we should try to store the most recent value
-- [ ] Implement `generate_feed_xml(feed_id)` to write to in-memory XML after acquiring write lock
-- [ ] Implement `get_feed_xml(feed_id)` for HTTP handlers to read from in-memory XML after acquiring read lock
+- [x] Implement `generate_feed_xml(feed_id)` to write to in-memory XML after acquiring write lock
+- [x] Implement `get_feed_xml(feed_id)` for HTTP handlers to read from in-memory XML after acquiring read lock
 - [ ] Write unit tests to verify enclosure URLs and MIME types in generated feeds
 - [ ] Not really related: maybe I can collapse the concepts of enqueuer and downloader into 1: basically skip the QUEUED state for any immediately ready videos (go straight to download). Only issue is then how do we queue upcoming videos? maybe explicit live handler? but then duplicate download logic?
-- [ ] Prevent magic values (url path, file path). maybe have an intermediate that knows all types of paths that file_manager and feedgen reach out to? or some unified type that can output both in a stable way?
-- [ ] Figure out how to bring in host url.
-- [ ] duration should be an int
+- [x] Figure out how to bring in host url.
+- [x] duration should be an int
+
+## 4.1 Path Management Centralization
+- [x] **PathManager Implementation** – Create centralized path/URL coordination class:
+  - [x] Single source of truth for file system paths and URLs based on feed_id + download_id
+  - [x] Consistent 1:1 mapping between network paths and file paths
+  - [x] Methods for feed directories, RSS URLs, and media file paths/URLs
+  - [x] Google-style docstrings with proper Args/Returns/Raises sections
+- [x] `FileManager` refactor
+- [x] `Pruner` refactor
+- [x] `RSSFeedGenerator` refactor
+- [x] tests refactor
 
 ## 5  Scheduler / Worker Loop
 - [ ] Init APScheduler (asyncio).

--- a/src/anypod/__init__.py
+++ b/src/anypod/__init__.py
@@ -1,0 +1,5 @@
+"""Top-level package for Anypod."""
+
+from .path_manager import PathManager
+
+__all__ = ["PathManager"]

--- a/src/anypod/__init__.py
+++ b/src/anypod/__init__.py
@@ -1,5 +1,0 @@
-"""Top-level package for Anypod."""
-
-from .path_manager import PathManager
-
-__all__ = ["PathManager"]

--- a/src/anypod/cli/cli.py
+++ b/src/anypod/cli/cli.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from ..config import AppSettings, DebugMode
 from ..logging_config import setup_logging
+from ..path_manager import PathManager
 from .debug_downloader import run_debug_downloader_mode
 from .debug_enqueuer import run_debug_enqueuer_mode
 from .debug_ytdlp import run_debug_ytdlp_mode
@@ -53,6 +54,12 @@ def main_cli():
         },
     )
 
+    paths = PathManager(
+        base_data_dir=DEBUG_DOWNLOADS_DIR,
+        base_tmp_dir=DEBUG_DOWNLOADS_DIR / "tmp",
+        base_url=settings.base_url,
+    )
+
     match settings.debug_mode:
         case DebugMode.YTDLP:
             debug_ytdlp_config_path = Path.cwd() / DEBUG_YTDLP_CONFIG_FILENAME
@@ -60,38 +67,29 @@ def main_cli():
                 "Initializing Anypod in 'ytdlp' debug mode.",
                 extra={"debug_config_file_path": str(debug_ytdlp_config_path)},
             )
-            app_tmp_dir = DEBUG_DOWNLOADS_DIR / "tmp"
-            app_tmp_dir.mkdir(parents=True, exist_ok=True)
             run_debug_ytdlp_mode(
                 debug_ytdlp_config_path,
-                DEBUG_DOWNLOADS_DIR,
-                app_tmp_dir,
+                paths,
             )
         case DebugMode.ENQUEUER:
             logger.info(
                 "Initializing Anypod in 'enqueuer' debug mode.",
                 extra={"feeds_config_file_path": str(settings.config_file)},
             )
-            app_tmp_dir = DEBUG_DOWNLOADS_DIR / "tmp"
-            app_tmp_dir.mkdir(parents=True, exist_ok=True)
             run_debug_enqueuer_mode(
                 settings,
                 DEBUG_DB_FILE,
-                DEBUG_DOWNLOADS_DIR,
-                app_tmp_dir,
+                paths,
             )
         case DebugMode.DOWNLOADER:
             logger.info(
                 "Initializing Anypod in 'downloader' debug mode.",
                 extra={"feeds_config_file_path": str(settings.config_file)},
             )
-            app_tmp_dir = DEBUG_DOWNLOADS_DIR / "tmp"
-            app_tmp_dir.mkdir(parents=True, exist_ok=True)
             run_debug_downloader_mode(
                 settings,
                 DEBUG_DB_FILE,
-                DEBUG_DOWNLOADS_DIR,
-                app_tmp_dir,
+                paths,
             )
         case None:
             logger.info("Initializing Anypod in default mode.")

--- a/src/anypod/cli/debug_downloader.py
+++ b/src/anypod/cli/debug_downloader.py
@@ -24,8 +24,7 @@ logger = logging.getLogger(__name__)
 def run_debug_downloader_mode(
     settings: AppSettings,
     debug_db_path: Path,
-    app_data_dir: Path,
-    app_tmp_dir: Path,
+    paths: PathManager,
 ) -> None:
     """Run the Downloader in debug mode to process queued downloads.
 
@@ -36,26 +35,19 @@ def run_debug_downloader_mode(
     Args:
         settings: Application settings containing feed configurations.
         debug_db_path: Path to the database file.
-        app_data_dir: Data directory for downloaded files.
-        app_tmp_dir: Temporary directory for yt-dlp operations.
+        paths: PathManager instance containing data and temporary directories.
     """
     logger.info(
         "Initializing Anypod in Downloader debug mode.",
         extra={
             "config_file": str(settings.config_file),
             "debug_db_path": str(debug_db_path.resolve()),
-            "debug_downloads_path": str(app_data_dir.resolve()),
+            "debug_downloads_path": str(paths.base_data_dir.resolve()),
         },
     )
 
     try:
         db_manager = DatabaseManager(db_path=debug_db_path)
-
-        paths = PathManager(
-            base_data_dir=app_data_dir,
-            base_tmp_dir=app_tmp_dir,
-            base_url=settings.base_url,
-        )
 
         file_manager = FileManager(paths)
 
@@ -157,9 +149,9 @@ def run_debug_downloader_mode(
             logger.info("No downloads found in the database.")
 
         # Show downloaded files on filesystem
-        if app_data_dir.exists():
+        if paths.base_data_dir.exists():
             logger.info("Files found in debug downloads directory:")
-            for feed_dir in app_data_dir.iterdir():
+            for feed_dir in paths.base_data_dir.iterdir():
                 if feed_dir.is_dir():
                     files = list(feed_dir.glob("*"))
                     if files:

--- a/src/anypod/cli/debug_downloader.py
+++ b/src/anypod/cli/debug_downloader.py
@@ -15,6 +15,7 @@ from ..data_coordinator.downloader import Downloader
 from ..db import DatabaseManager, Download, DownloadStatus
 from ..exceptions import DatabaseOperationError, DownloadError
 from ..file_manager import FileManager
+from ..path_manager import PathManager
 from ..ytdlp_wrapper import YtdlpWrapper
 
 logger = logging.getLogger(__name__)
@@ -50,12 +51,15 @@ def run_debug_downloader_mode(
     try:
         db_manager = DatabaseManager(db_path=debug_db_path)
 
-        file_manager = FileManager(base_download_path=app_data_dir)
-
-        ytdlp_wrapper = YtdlpWrapper(
-            app_tmp_dir,
-            app_data_dir,
+        paths = PathManager(
+            base_data_dir=app_data_dir,
+            base_tmp_dir=app_tmp_dir,
+            base_url=settings.base_url,
         )
+
+        file_manager = FileManager(paths)
+
+        ytdlp_wrapper = YtdlpWrapper(paths)
         downloader = Downloader(db_manager, file_manager, ytdlp_wrapper)
     except Exception as e:
         logger.critical(

--- a/src/anypod/cli/debug_enqueuer.py
+++ b/src/anypod/cli/debug_enqueuer.py
@@ -21,8 +21,7 @@ logger = logging.getLogger(__name__)
 def run_debug_enqueuer_mode(
     settings: AppSettings,
     debug_db_path: Path,
-    app_data_dir: Path,
-    app_tmp_dir: Path,
+    paths: PathManager,
 ) -> None:
     """Run the Enqueuer in debug mode to process feed metadata.
 
@@ -33,8 +32,7 @@ def run_debug_enqueuer_mode(
     Args:
         settings: Application settings containing feed configurations.
         debug_db_path: Path to the database file.
-        app_data_dir: Data directory for downloaded files.
-        app_tmp_dir: Temporary directory for yt-dlp operations.
+        paths: PathManager instance containing data and temporary directories.
     """
     logger.info(
         "Initializing Anypod in Enqueuer debug mode.",
@@ -46,12 +44,6 @@ def run_debug_enqueuer_mode(
 
     try:
         db_manager = DatabaseManager(db_path=debug_db_path)
-
-        paths = PathManager(
-            base_data_dir=app_data_dir,
-            base_tmp_dir=app_tmp_dir,
-            base_url=settings.base_url,
-        )
 
         ytdlp_wrapper = YtdlpWrapper(paths)
         enqueuer = Enqueuer(db_manager, ytdlp_wrapper)

--- a/src/anypod/cli/debug_enqueuer.py
+++ b/src/anypod/cli/debug_enqueuer.py
@@ -12,6 +12,7 @@ from ..config import AppSettings
 from ..data_coordinator.enqueuer import Enqueuer
 from ..db import DatabaseManager, Download, DownloadStatus
 from ..exceptions import DatabaseOperationError, EnqueueError
+from ..path_manager import PathManager
 from ..ytdlp_wrapper import YtdlpWrapper
 
 logger = logging.getLogger(__name__)
@@ -46,10 +47,13 @@ def run_debug_enqueuer_mode(
     try:
         db_manager = DatabaseManager(db_path=debug_db_path)
 
-        ytdlp_wrapper = YtdlpWrapper(
-            app_tmp_dir,
-            app_data_dir,
+        paths = PathManager(
+            base_data_dir=app_data_dir,
+            base_tmp_dir=app_tmp_dir,
+            base_url=settings.base_url,
         )
+
+        ytdlp_wrapper = YtdlpWrapper(paths)
         enqueuer = Enqueuer(db_manager, ytdlp_wrapper)
     except Exception as e:
         logger.critical(

--- a/src/anypod/cli/debug_ytdlp.py
+++ b/src/anypod/cli/debug_ytdlp.py
@@ -13,6 +13,7 @@ import yaml
 
 from ..db import DownloadStatus
 from ..exceptions import YtdlpApiError
+from ..path_manager import PathManager
 from ..ytdlp_wrapper import YtdlpWrapper
 from ..ytdlp_wrapper.ytdlp_core import YtdlpCore
 
@@ -76,7 +77,13 @@ def run_debug_ytdlp_mode(
         )
         return
 
-    ytdlp_wrapper = YtdlpWrapper(app_tmp_dir, app_data_dir)
+    paths = PathManager(
+        base_data_dir=app_data_dir,
+        base_tmp_dir=app_tmp_dir,
+        base_url="http://localhost",
+    )
+
+    ytdlp_wrapper = YtdlpWrapper(paths)
     logger.debug("YtdlpWrapper initialized for debug mode.")
 
     logger.info(

--- a/src/anypod/cli/debug_ytdlp.py
+++ b/src/anypod/cli/debug_ytdlp.py
@@ -23,9 +23,7 @@ from ..ytdlp_wrapper.ytdlp_core import YtdlpCore
 logger = logging.getLogger(__name__)
 
 
-def run_debug_ytdlp_mode(
-    debug_yaml_path: Path, app_data_dir: Path, app_tmp_dir: Path
-) -> None:
+def run_debug_ytdlp_mode(debug_yaml_path: Path, paths: PathManager) -> None:
     """Load feed URLs from YAML and fetch metadata using yt-dlp.
 
     Loads feed URLs and yt-dlp CLI args from a YAML file and fetches metadata.
@@ -33,8 +31,7 @@ def run_debug_ytdlp_mode(
 
     Args:
         debug_yaml_path: Path to the YAML configuration file.
-        app_data_dir: Data directory for downloaded files.
-        app_tmp_dir: Temporary directory for yt-dlp operations.
+        paths: PathManager instance containing data and temporary directories.
     """
     logger.debug(
         "Entered yt-dlp debug mode execution.",
@@ -76,12 +73,6 @@ def run_debug_ytdlp_mode(
             extra={"config_path": str(debug_yaml_path)},
         )
         return
-
-    paths = PathManager(
-        base_data_dir=app_data_dir,
-        base_tmp_dir=app_tmp_dir,
-        base_url="http://localhost",
-    )
 
     ytdlp_wrapper = YtdlpWrapper(paths)
     logger.debug("YtdlpWrapper initialized for debug mode.")

--- a/src/anypod/data_coordinator/pruner.py
+++ b/src/anypod/data_coordinator/pruner.py
@@ -131,7 +131,7 @@ class Pruner:
         )
 
         try:
-            self.file_manager.delete_download_file(feed_id, file_name)
+            self.file_manager.delete_download_file(feed_id, download.id, download.ext)
         except FileOperationError as e:
             raise PruneError(
                 message="Failed to delete file during pruning.",

--- a/src/anypod/file_manager.py
+++ b/src/anypod/file_manager.py
@@ -22,52 +22,38 @@ class FileManager:
     in feed-specific subdirectories.
 
     Attributes:
-        base_download_path: The root path where all download files are stored.
+        _paths: PathManager instance for coordinating file paths and URLs.
     """
 
     def __init__(self, paths: PathManager):
-        """Initialize the FileManager with a ``PathManager`` instance.
-
-        Args:
-            paths: Manager providing base directories for downloads.
-
-        Raises:
-            FileOperationError: If the base download directory cannot be created.
-        """
         self._paths = paths
-        self.base_download_path = paths.base_data_dir
         logger.debug(
             "FileManager initialized.",
-            extra={"base_download_path": str(self.base_download_path)},
+            extra={"base_download_path": str(self._paths.base_data_dir)},
         )
-        # Ensure the base download directory exists upon instantiation.
-        try:
-            self.base_download_path.mkdir(parents=True, exist_ok=True)
-            logger.debug(
-                "Base download directory exists.",
-                extra={"base_download_path": str(self.base_download_path)},
-            )
-        except OSError as e:
-            raise FileOperationError(
-                "Failed to create base download directory.",
-                file_name=str(self.base_download_path),
-            ) from e
 
-    def delete_download_file(self, feed: str, file_name: str) -> None:
+    def delete_download_file(self, feed: str, download_id: str, ext: str) -> None:
         """Deletes a download file from the filesystem.
 
         Args:
             feed: The name of the feed.
-            file_name: The name of the download file to be deleted.
+            download_id: The unique identifier for the download.
+            ext: File extension without the leading dot.
 
         Raises:
             FileNotFoundError: If the file does not exist or is not a regular file.
-            FileOperationError: If an OS-level error occurs during file deletion (e.g., PermissionError).
+            FileOperationError: If an OS-level error occurs during file deletion, or if feed/download identifiers are invalid.
         """
-        file_path = self._paths.feed_data_dir(feed) / file_name
+        try:
+            file_path = self._paths.media_file_path(feed, download_id, ext)
+        except ValueError as e:
+            raise FileOperationError(
+                "Invalid feed or download identifier.",
+                feed_id=feed,
+                download_id=download_id,
+            ) from e
         log_params = {
             "feed_id": feed,
-            "file_name": file_name,
             "file_path": str(file_path),
         }
         logger.debug("Attempting to delete download file.", extra=log_params)
@@ -81,26 +67,33 @@ class FileManager:
             except OSError as e:
                 raise FileOperationError(
                     "Failed to delete download file.",
-                    file_name=file_name,
+                    file_name=f"{download_id}.{ext}",
                 ) from e
 
-    def download_exists(self, feed: str, file_name: str) -> bool:
+    def download_exists(self, feed: str, download_id: str, ext: str) -> bool:
         """Checks if a specific download file exists.
 
         Args:
             feed: The name of the feed (subdirectory).
-            file_name: The name of the download file.
+            download_id: The unique identifier for the download.
+            ext: File extension without the leading dot.
 
         Returns:
             True if the file exists and is a file, False otherwise.
 
         Raises:
-            FileOperationError: If an OS-level error occurs during the file existence check (e.g., PermissionError on a parent directory).
+            FileOperationError: If an OS-level error occurs during the file existence check, or if feed/download identifiers are invalid.
         """
-        file_path = self._paths.feed_data_dir(feed) / file_name
+        try:
+            file_path = self._paths.media_file_path(feed, download_id, ext)
+        except ValueError as e:
+            raise FileOperationError(
+                "Invalid feed or download identifier.",
+                feed_id=feed,
+                download_id=download_id,
+            ) from e
         log_params = {
             "feed_id": feed,
-            "file_name": file_name,
             "file_path": str(file_path),
         }
         logger.debug("Checking if download file exists.", extra=log_params)
@@ -114,29 +107,36 @@ class FileManager:
                 file_name=str(file_path),
             ) from e
 
-    def get_download_stream(self, feed: str, file_name: str) -> IO[bytes]:
+    def get_download_stream(self, feed: str, download_id: str, ext: str) -> IO[bytes]:
         """Opens and returns a binary read stream for a download file.
 
         Args:
             feed: The name of the feed (subdirectory).
-            file_name: The name of the download file.
+            download_id: The unique identifier for the download.
+            ext: File extension without the leading dot.
 
         Returns:
             An IO[bytes] stream for the download file.
 
         Raises:
             FileNotFoundError: If the file does not exist or is not a regular file.
-            FileOperationError: If an OS-level error occurs while trying to open the file (e.g., PermissionError).
+            FileOperationError: If an OS-level error occurs while trying to open the file, or if feed/download identifiers are invalid.
         """
-        file_path = self._paths.feed_data_dir(feed) / file_name
+        try:
+            file_path = self._paths.media_file_path(feed, download_id, ext)
+        except ValueError as e:
+            raise FileOperationError(
+                "Invalid feed or download identifier.",
+                feed_id=feed,
+                download_id=download_id,
+            ) from e
         log_params = {
             "feed_id": feed,
-            "file_name": file_name,
             "file_path": str(file_path),
         }
         logger.debug("Attempting to get download stream.", extra=log_params)
 
-        if not self.download_exists(feed, file_name):
+        if not self.download_exists(feed, download_id, ext):
             logger.debug(
                 "File not found, cannot get stream.",
                 extra=log_params,

--- a/src/anypod/file_manager.py
+++ b/src/anypod/file_manager.py
@@ -6,10 +6,10 @@ operations. Notably does not handle file creation, as that is done by yt-dlp.
 """
 
 import logging
-from pathlib import Path
 from typing import IO
 
 from .exceptions import FileOperationError
+from .path_manager import PathManager
 
 logger = logging.getLogger(__name__)
 
@@ -25,17 +25,17 @@ class FileManager:
         base_download_path: The root path where all download files are stored.
     """
 
-    def __init__(self, base_download_path: Path):
-        """Initializes the FileManager with the base directory for download storage.
+    def __init__(self, paths: PathManager):
+        """Initialize the FileManager with a ``PathManager`` instance.
 
         Args:
-            base_download_path: The root path where all download files will be stored.
-                               Feed-specific subdirectories will be created under this path.
+            paths: Manager providing base directories for downloads.
 
         Raises:
             FileOperationError: If the base download directory cannot be created.
         """
-        self.base_download_path = Path(base_download_path).resolve()
+        self._paths = paths
+        self.base_download_path = paths.base_data_dir
         logger.debug(
             "FileManager initialized.",
             extra={"base_download_path": str(self.base_download_path)},
@@ -64,7 +64,7 @@ class FileManager:
             FileNotFoundError: If the file does not exist or is not a regular file.
             FileOperationError: If an OS-level error occurs during file deletion (e.g., PermissionError).
         """
-        file_path = self.base_download_path / feed / file_name
+        file_path = self._paths.feed_data_dir(feed) / file_name
         log_params = {
             "feed_id": feed,
             "file_name": file_name,
@@ -97,7 +97,7 @@ class FileManager:
         Raises:
             FileOperationError: If an OS-level error occurs during the file existence check (e.g., PermissionError on a parent directory).
         """
-        file_path = self.base_download_path / feed / file_name
+        file_path = self._paths.feed_data_dir(feed) / file_name
         log_params = {
             "feed_id": feed,
             "file_name": file_name,
@@ -128,7 +128,7 @@ class FileManager:
             FileNotFoundError: If the file does not exist or is not a regular file.
             FileOperationError: If an OS-level error occurs while trying to open the file (e.g., PermissionError).
         """
-        file_path = self.base_download_path / feed / file_name
+        file_path = self._paths.feed_data_dir(feed) / file_name
         log_params = {
             "feed_id": feed,
             "file_name": file_name,

--- a/src/anypod/path_manager.py
+++ b/src/anypod/path_manager.py
@@ -5,12 +5,23 @@ from __future__ import annotations
 from pathlib import Path
 from urllib.parse import urljoin
 
+from .exceptions import FileOperationError
+
 
 class PathManager:
-    """Coordinate download paths and URLs for feeds."""
+    """Centralized management of file system paths and URLs for all feeds.
+
+    Provides a single source of truth for both file system location and URL
+    construction for feeds and their media files. Ensures consistent 1:1 mapping
+    between network paths and file paths based on feed_id and download_id.
+
+    Attributes:
+        _base_data_dir: Root directory for permanent download storage.
+        _base_tmp_dir: Root directory for temporary download operations.
+        _base_url: Base URL for constructing feed and media URLs.
+    """
 
     def __init__(self, base_data_dir: Path, base_tmp_dir: Path, base_url: str):
-        """Initialize the manager with base directories and URL."""
         self._base_data_dir = Path(base_data_dir).resolve()
         self._base_tmp_dir = Path(base_tmp_dir).resolve()
         self._base_url = base_url.rstrip("/")
@@ -31,29 +42,129 @@ class PathManager:
         return self._base_url
 
     def feed_data_dir(self, feed_id: str) -> Path:
-        """Return the directory for a feed's downloaded files."""
+        """Return the directory for a feed's downloaded files.
+
+        Creates the directory if it doesn't exist.
+
+        Args:
+            feed_id: Unique identifier for the feed.
+
+        Returns:
+            Path to the feed's data directory.
+
+        Raises:
+            ValueError: If feed_id is empty or whitespace-only.
+            FileOperationError: If the directory cannot be created.
+        """
+        if not feed_id or not feed_id.strip():
+            raise ValueError("feed_id cannot be empty or whitespace-only")
+
         path = self._base_data_dir / feed_id
-        path.mkdir(parents=True, exist_ok=True)
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            raise FileOperationError(
+                "Failed to create feed data directory.",
+                file_name=str(path),
+            ) from e
         return path
 
     def feed_tmp_dir(self, feed_id: str) -> Path:
-        """Return the temporary directory for a feed."""
+        """Return the temporary directory for a feed.
+
+        Creates the directory if it doesn't exist.
+
+        Args:
+            feed_id: Unique identifier for the feed.
+
+        Returns:
+            Path to the feed's temporary directory.
+
+        Raises:
+            ValueError: If feed_id is empty or whitespace-only.
+            FileOperationError: If the directory cannot be created.
+        """
+        if not feed_id or not feed_id.strip():
+            raise ValueError("feed_id cannot be empty or whitespace-only")
+
         path = self._base_tmp_dir / feed_id
-        path.mkdir(parents=True, exist_ok=True)
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            raise FileOperationError(
+                "Failed to create feed temporary directory.",
+                file_name=str(path),
+            ) from e
         return path
 
     def feed_url(self, feed_id: str) -> str:
-        """Return the full URL for a feed's RSS XML."""
+        """Return the full URL for a feed's RSS XML.
+
+        Args:
+            feed_id: Unique identifier for the feed.
+
+        Returns:
+            Complete URL to the RSS feed XML file.
+
+        Raises:
+            ValueError: If feed_id is empty or whitespace-only.
+        """
+        if not feed_id or not feed_id.strip():
+            raise ValueError("feed_id cannot be empty or whitespace-only")
+
         return urljoin(self._base_url, f"/feeds/{feed_id}.xml")
 
     def feed_media_url(self, feed_id: str) -> str:
-        """Return the base URL for a feed's media files."""
+        """Return the base URL for a feed's media files.
+
+        Args:
+            feed_id: Unique identifier for the feed.
+
+        Returns:
+            Base URL for accessing the feed's media files.
+
+        Raises:
+            ValueError: If feed_id is empty or whitespace-only.
+        """
+        if not feed_id or not feed_id.strip():
+            raise ValueError("feed_id cannot be empty or whitespace-only")
+
         return urljoin(self._base_url, f"/media/{feed_id}/")
 
     def media_file_path(self, feed_id: str, download_id: str, ext: str) -> Path:
-        """Return the full path for a specific downloaded file."""
+        """Return the full file system path for a specific downloaded media file.
+
+        Args:
+            feed_id: Unique identifier for the feed.
+            download_id: Unique identifier for the download.
+            ext: File extension without the leading dot.
+
+        Returns:
+            Complete path to the media file on disk.
+
+        Raises:
+            ValueError: If feed_id or download_id is empty or whitespace-only.
+        """
+        if not download_id or not download_id.strip():
+            raise ValueError("download_id cannot be empty or whitespace-only")
+
         return self.feed_data_dir(feed_id) / f"{download_id}.{ext}"
 
     def media_file_url(self, feed_id: str, download_id: str, ext: str) -> str:
-        """Return the URL for a specific downloaded file."""
-        return urljoin(self._base_url, f"/media/{feed_id}/{download_id}.{ext}")
+        """Return the HTTP URL for a specific downloaded media file.
+
+        Args:
+            feed_id: Unique identifier for the feed.
+            download_id: Unique identifier for the download.
+            ext: File extension without the leading dot.
+
+        Returns:
+            Complete URL for accessing the media file via HTTP.
+
+        Raises:
+            ValueError: If feed_id or download_id is empty or whitespace-only.
+        """
+        if not download_id or not download_id.strip():
+            raise ValueError("download_id cannot be empty or whitespace-only")
+
+        return urljoin(self.feed_media_url(feed_id), f"{download_id}.{ext}")

--- a/src/anypod/path_manager.py
+++ b/src/anypod/path_manager.py
@@ -1,0 +1,59 @@
+"""Helpers for resolving file system paths and URLs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import urljoin
+
+
+class PathManager:
+    """Coordinate download paths and URLs for feeds."""
+
+    def __init__(self, base_data_dir: Path, base_tmp_dir: Path, base_url: str):
+        """Initialize the manager with base directories and URL."""
+        self._base_data_dir = Path(base_data_dir).resolve()
+        self._base_tmp_dir = Path(base_tmp_dir).resolve()
+        self._base_url = base_url.rstrip("/")
+
+    @property
+    def base_data_dir(self) -> Path:
+        """Return the directory used for permanent downloads."""
+        return self._base_data_dir
+
+    @property
+    def base_tmp_dir(self) -> Path:
+        """Return the directory used for temporary downloads."""
+        return self._base_tmp_dir
+
+    @property
+    def base_url(self) -> str:
+        """Return the base URL for feed and media links."""
+        return self._base_url
+
+    def feed_data_dir(self, feed_id: str) -> Path:
+        """Return the directory for a feed's downloaded files."""
+        path = self._base_data_dir / feed_id
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def feed_tmp_dir(self, feed_id: str) -> Path:
+        """Return the temporary directory for a feed."""
+        path = self._base_tmp_dir / feed_id
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def feed_url(self, feed_id: str) -> str:
+        """Return the full URL for a feed's RSS XML."""
+        return urljoin(self._base_url, f"/feeds/{feed_id}.xml")
+
+    def feed_media_url(self, feed_id: str) -> str:
+        """Return the base URL for a feed's media files."""
+        return urljoin(self._base_url, f"/media/{feed_id}/")
+
+    def media_file_path(self, feed_id: str, download_id: str, ext: str) -> Path:
+        """Return the full path for a specific downloaded file."""
+        return self.feed_data_dir(feed_id) / f"{download_id}.{ext}"
+
+    def media_file_url(self, feed_id: str, download_id: str, ext: str) -> str:
+        """Return the URL for a specific downloaded file."""
+        return urljoin(self._base_url, f"/media/{feed_id}/{download_id}.{ext}")

--- a/src/anypod/rss/feedgen_core.py
+++ b/src/anypod/rss/feedgen_core.py
@@ -6,12 +6,11 @@ operations of feedgen and provides a clean interface for creating RSS feeds
 from Anypod download data.
 """
 
-from urllib.parse import urljoin
-
 from feedgen.feed import FeedGenerator  # type: ignore
 
 from anypod.config import FeedConfig
 from anypod.db import Download
+from anypod.exceptions import RSSGenerationError
 from anypod.path_manager import PathManager
 
 
@@ -29,7 +28,7 @@ class FeedgenCore:
 
     Attributes:
         _fg: Internal FeedGenerator instance.
-        _download_folder_url: Base URL for download file links.
+        _paths: PathManager instance for resolving URLs and paths.
         _feed_config: Feed configuration reference.
     """
 
@@ -40,8 +39,16 @@ class FeedgenCore:
         fg = FeedGenerator()  # type: ignore
         fg.load_extension("podcast")  # type: ignore
 
+        try:
+            feed_self_url = paths.feed_url(feed_id)
+        except ValueError as e:
+            raise RSSGenerationError(
+                "Invalid feed identifier for RSS URL.",
+                feed_id=feed_id,
+            ) from e
+
         fg.title(feed_config.metadata.title)  # type: ignore
-        fg.link(href=paths.feed_url(feed_id), rel="self")  # type: ignore
+        fg.link(href=feed_self_url, rel="self")  # type: ignore
         fg.link(href=feed_config.url, rel="alternate")  # type: ignore
         fg.description(feed_config.metadata.description)  # type: ignore
         fg.podcast.itunes_summary(feed_config.metadata.description)  # type: ignore
@@ -67,7 +74,6 @@ class FeedgenCore:
 
         self._fg = fg  # type: ignore
         self._paths = paths
-        self._download_folder_url = paths.feed_media_url(feed_id)
         self._feed_config = feed_config
         self._feed_metadata = feed_config.metadata
 
@@ -85,7 +91,7 @@ class FeedgenCore:
             fe = self._fg.add_entry(order="append")  # type: ignore
 
             fe.guid(  # type: ignore
-                urljoin(self._download_folder_url, download.source_url), permalink=True
+                download.source_url, permalink=True
             )
             fe.title(download.title)  # type: ignore
             fe.podcast.itunes_title(download.title)  # type: ignore
@@ -98,10 +104,18 @@ class FeedgenCore:
             if download.thumbnail:
                 fe.podcast.itunes_image(download.thumbnail)  # type: ignore
 
-            fe.enclosure(  # type: ignore
-                url=self._paths.media_file_url(
+            try:
+                media_url = self._paths.media_file_url(
                     download.feed, download.id, download.ext
-                ),
+                )
+            except ValueError as e:
+                raise RSSGenerationError(
+                    "Invalid feed or download identifier for media URL.",
+                    feed_id=download.feed,
+                ) from e
+
+            fe.enclosure(  # type: ignore
+                url=media_url,
                 length=download.filesize or 0,
                 type=download.mime_type,
             )

--- a/src/anypod/ytdlp_wrapper/ytdlp_wrapper.py
+++ b/src/anypod/ytdlp_wrapper/ytdlp_wrapper.py
@@ -37,13 +37,11 @@ class YtdlpWrapper:
 
     def __init__(self, paths: PathManager):
         self._paths = paths
-        self._app_tmp_dir = paths.base_tmp_dir
-        self._app_data_dir = paths.base_data_dir
         logger.debug(
             "YtdlpWrapper initialized.",
             extra={
-                "app_tmp_dir": str(self._app_tmp_dir),
-                "app_data_dir": str(self._app_data_dir),
+                "app_tmp_dir": str(self._paths.base_tmp_dir),
+                "app_data_dir": str(self._paths.base_data_dir),
             },
         )
 
@@ -51,6 +49,11 @@ class YtdlpWrapper:
         try:
             feed_temp_path = self._paths.feed_tmp_dir(feed_id)
             feed_data_path = self._paths.feed_data_dir(feed_id)
+        except ValueError as e:
+            raise YtdlpApiError(
+                message="Invalid feed identifier for yt-dlp paths.",
+                feed_id=feed_id,
+            ) from e
         except OSError as e:
             raise YtdlpApiError(
                 message="Failed to create directories for yt-dlp paths.",

--- a/src/anypod/ytdlp_wrapper/ytdlp_wrapper.py
+++ b/src/anypod/ytdlp_wrapper/ytdlp_wrapper.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from ..db import Download
 from ..exceptions import YtdlpApiError
+from ..path_manager import PathManager
 from .base_handler import FetchPurpose, ReferenceType, SourceHandlerBase
 from .youtube_handler import YoutubeHandler
 from .ytdlp_core import YtdlpCore, YtdlpInfo
@@ -34,9 +35,10 @@ class YtdlpWrapper:
 
     _source_handler: SourceHandlerBase = YoutubeHandler()
 
-    def __init__(self, app_tmp_dir: Path, app_data_dir: Path):
-        self._app_tmp_dir = app_tmp_dir.resolve()
-        self._app_data_dir = app_data_dir.resolve()
+    def __init__(self, paths: PathManager):
+        self._paths = paths
+        self._app_tmp_dir = paths.base_tmp_dir
+        self._app_data_dir = paths.base_data_dir
         logger.debug(
             "YtdlpWrapper initialized.",
             extra={
@@ -46,15 +48,12 @@ class YtdlpWrapper:
         )
 
     def _prepare_download_dir(self, feed_id: str) -> tuple[Path, Path]:
-        feed_temp_path = self._app_tmp_dir / feed_id
-        feed_data_path = self._app_data_dir / feed_id
-
         try:
-            feed_temp_path.mkdir(parents=True, exist_ok=True)
-            feed_data_path.mkdir(parents=True, exist_ok=True)
+            feed_temp_path = self._paths.feed_tmp_dir(feed_id)
+            feed_data_path = self._paths.feed_data_dir(feed_id)
         except OSError as e:
             raise YtdlpApiError(
-                message=f"Failed to create directories for yt-dlp paths (temp: {feed_temp_path}, data: {feed_data_path})",
+                message="Failed to create directories for yt-dlp paths.",
                 feed_id=feed_id,
             ) from e
 

--- a/tests/anypod/data_coordinator/test_pruner.py
+++ b/tests/anypod/data_coordinator/test_pruner.py
@@ -238,7 +238,7 @@ def test_handle_file_deletion_success(
     pruner._handle_file_deletion(sample_downloaded_item, "test_feed")
 
     mock_file_manager.delete_download_file.assert_called_once_with(
-        "test_feed", "test_dl_id_1.mp4"
+        "test_feed", "test_dl_id_1", "mp4"
     )
 
 
@@ -330,7 +330,7 @@ def test_process_single_download_downloaded_file_deleted_successfully(
 
     assert result is True
     mock_file_manager.delete_download_file.assert_called_once_with(
-        "test_feed", "test_dl_id_1.mp4"
+        "test_feed", "test_dl_id_1", "mp4"
     )
     mock_db_manager.archive_download.assert_called_once_with(
         "test_feed", sample_downloaded_item.id
@@ -355,7 +355,7 @@ def test_process_single_download_downloaded_file_not_found_returns_false(
 
     assert result is False
     mock_file_manager.delete_download_file.assert_called_once_with(
-        "test_feed", "test_dl_id_1.mp4"
+        "test_feed", "test_dl_id_1", "mp4"
     )
     mock_db_manager.archive_download.assert_called_once_with(
         "test_feed", sample_downloaded_item.id

--- a/tests/anypod/test_file_manager.py
+++ b/tests/anypod/test_file_manager.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from anypod.file_manager import FileManager
+from anypod.path_manager import PathManager
 
 # --- Fixtures ---
 
@@ -19,9 +20,13 @@ def temp_base_download_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 
 @pytest.fixture
-def file_manager(temp_base_download_path: Path) -> FileManager:
+def file_manager(
+    tmp_path_factory: pytest.TempPathFactory, temp_base_download_path: Path
+) -> FileManager:
     """Provides a FileManager instance initialized with a temporary base download path."""
-    fm = FileManager(base_download_path=temp_base_download_path)
+    tmp_dir = tmp_path_factory.mktemp("tmp")
+    paths = PathManager(temp_base_download_path, tmp_dir, "http://localhost")
+    fm = FileManager(paths)
     return fm
 
 

--- a/tests/anypod/test_path_manager.py
+++ b/tests/anypod/test_path_manager.py
@@ -1,0 +1,400 @@
+# pyright: reportPrivateUsage=false
+
+"""Tests for the PathManager class and its path/URL generation functionality."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from anypod.exceptions import FileOperationError
+from anypod.path_manager import PathManager
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def tmp_dirs(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, Path]:
+    """Creates temporary data and tmp directories for tests."""
+    data_dir = tmp_path_factory.mktemp("test_data")
+    tmp_dir = tmp_path_factory.mktemp("test_tmp")
+    return data_dir, tmp_dir
+
+
+@pytest.fixture
+def path_manager(tmp_dirs: tuple[Path, Path]) -> PathManager:
+    """Provides a PathManager instance with temporary directories."""
+    data_dir, tmp_dir = tmp_dirs
+    return PathManager(data_dir, tmp_dir, "http://localhost:8024")
+
+
+# --- Tests for initialization and properties ---
+
+
+@pytest.mark.unit
+def test_init_normalizes_paths(tmp_path_factory: pytest.TempPathFactory):
+    """Tests that PathManager normalizes and resolves provided paths."""
+    data_dir = tmp_path_factory.mktemp("data")
+    tmp_dir = tmp_path_factory.mktemp("tmp")
+    base_url = "http://example.com/"
+
+    # Test with relative paths and trailing slash in URL
+    path_manager = PathManager(data_dir / "..", tmp_dir / "subdir" / "..", base_url)
+
+    assert path_manager.base_data_dir == data_dir.parent.resolve()
+    assert path_manager.base_tmp_dir == tmp_dir.resolve()
+    assert path_manager.base_url == "http://example.com"
+
+
+@pytest.mark.unit
+def test_properties_return_correct_values(
+    path_manager: PathManager, tmp_dirs: tuple[Path, Path]
+):
+    """Tests that properties return the initialized values."""
+    data_dir, tmp_dir = tmp_dirs
+
+    assert path_manager.base_data_dir == data_dir.resolve()
+    assert path_manager.base_tmp_dir == tmp_dir.resolve()
+    assert path_manager.base_url == "http://localhost:8024"
+
+
+# --- Tests for feed_data_dir ---
+
+
+@pytest.mark.unit
+def test_feed_data_dir_creates_directory(path_manager: PathManager):
+    """Tests that feed_data_dir creates the directory if it doesn't exist."""
+    feed_id = "test_feed"
+
+    feed_dir = path_manager.feed_data_dir(feed_id)
+
+    assert feed_dir.exists()
+    assert feed_dir.is_dir()
+    assert feed_dir.name == feed_id
+    assert feed_dir.parent == path_manager.base_data_dir
+
+
+@pytest.mark.unit
+def test_feed_data_dir_idempotent(path_manager: PathManager):
+    """Tests that calling feed_data_dir multiple times is safe."""
+    feed_id = "idempotent_feed"
+
+    first_call = path_manager.feed_data_dir(feed_id)
+    second_call = path_manager.feed_data_dir(feed_id)
+
+    assert first_call == second_call
+    assert first_call.exists()
+
+
+@pytest.mark.unit
+def test_feed_data_dir_handles_mkdir_error(path_manager: PathManager):
+    """Tests that feed_data_dir handles directory creation errors properly."""
+    feed_id = "error_feed"
+
+    with patch.object(Path, "mkdir", side_effect=OSError("Permission denied")):
+        with pytest.raises(FileOperationError) as exc_info:
+            path_manager.feed_data_dir(feed_id)
+
+        assert exc_info.value.file_name is not None
+        assert feed_id in exc_info.value.file_name
+
+
+# --- Tests for feed_tmp_dir ---
+
+
+@pytest.mark.unit
+def test_feed_tmp_dir_creates_directory(path_manager: PathManager):
+    """Tests that feed_tmp_dir creates the directory if it doesn't exist."""
+    feed_id = "temp_feed"
+
+    tmp_dir = path_manager.feed_tmp_dir(feed_id)
+
+    assert tmp_dir.exists()
+    assert tmp_dir.is_dir()
+    assert tmp_dir.name == feed_id
+    assert tmp_dir.parent == path_manager.base_tmp_dir
+
+
+@pytest.mark.unit
+def test_feed_tmp_dir_idempotent(path_manager: PathManager):
+    """Tests that calling feed_tmp_dir multiple times is safe."""
+    feed_id = "idempotent_tmp"
+
+    first_call = path_manager.feed_tmp_dir(feed_id)
+    second_call = path_manager.feed_tmp_dir(feed_id)
+
+    assert first_call == second_call
+    assert first_call.exists()
+
+
+@pytest.mark.unit
+def test_feed_tmp_dir_handles_mkdir_error(path_manager: PathManager):
+    """Tests that feed_tmp_dir handles directory creation errors properly."""
+    feed_id = "tmp_error_feed"
+
+    with patch.object(Path, "mkdir", side_effect=OSError("Disk full")):
+        with pytest.raises(FileOperationError) as exc_info:
+            path_manager.feed_tmp_dir(feed_id)
+
+        assert exc_info.value.file_name is not None
+        assert feed_id in exc_info.value.file_name
+
+
+# --- Tests for URL generation methods ---
+
+
+@pytest.mark.unit
+def test_feed_url_generation(path_manager: PathManager):
+    """Tests that feed_url generates correct RSS feed URLs."""
+    feed_id = "my_podcast"
+
+    url = path_manager.feed_url(feed_id)
+
+    assert url == "http://localhost:8024/feeds/my_podcast.xml"
+
+
+@pytest.mark.unit
+def test_feed_url_special_characters(path_manager: PathManager):
+    """Tests feed_url with special characters in feed_id."""
+    feed_id = "feed-with_special.chars"
+
+    url = path_manager.feed_url(feed_id)
+
+    assert url == "http://localhost:8024/feeds/feed-with_special.chars.xml"
+
+
+@pytest.mark.unit
+def test_feed_media_url_generation(path_manager: PathManager):
+    """Tests that feed_media_url generates correct base media URLs."""
+    feed_id = "video_feed"
+
+    url = path_manager.feed_media_url(feed_id)
+
+    assert url == "http://localhost:8024/media/video_feed/"
+
+
+@pytest.mark.unit
+def test_media_file_url_generation(path_manager: PathManager):
+    """Tests that media_file_url generates correct individual file URLs."""
+    feed_id = "content_feed"
+    download_id = "video_123"
+    ext = "mp4"
+
+    url = path_manager.media_file_url(feed_id, download_id, ext)
+
+    assert url == "http://localhost:8024/media/content_feed/video_123.mp4"
+
+
+@pytest.mark.unit
+def test_media_file_url_different_extensions(path_manager: PathManager):
+    """Tests media_file_url with various file extensions."""
+    feed_id = "multi_format"
+    download_id = "item_456"
+
+    # Test different extensions
+    mp4_url = path_manager.media_file_url(feed_id, download_id, "mp4")
+    webm_url = path_manager.media_file_url(feed_id, download_id, "webm")
+    m4a_url = path_manager.media_file_url(feed_id, download_id, "m4a")
+
+    assert mp4_url == "http://localhost:8024/media/multi_format/item_456.mp4"
+    assert webm_url == "http://localhost:8024/media/multi_format/item_456.webm"
+    assert m4a_url == "http://localhost:8024/media/multi_format/item_456.m4a"
+
+
+# --- Tests for file path generation methods ---
+
+
+@pytest.mark.unit
+def test_media_file_path_generation(path_manager: PathManager):
+    """Tests that media_file_path generates correct file system paths."""
+    feed_id = "path_test"
+    download_id = "video_789"
+    ext = "mp4"
+
+    file_path = path_manager.media_file_path(feed_id, download_id, ext)
+
+    expected_path = path_manager.base_data_dir / feed_id / f"{download_id}.{ext}"
+    assert file_path == expected_path
+
+
+@pytest.mark.unit
+def test_media_file_path_creates_parent_dir(path_manager: PathManager):
+    """Tests that media_file_path creates the parent directory."""
+    feed_id = "new_feed_dir"
+    download_id = "first_video"
+    ext = "webm"
+
+    file_path = path_manager.media_file_path(feed_id, download_id, ext)
+
+    # The parent directory should be created by the call to feed_data_dir
+    assert file_path.parent.exists()
+    assert file_path.parent.name == feed_id
+
+
+@pytest.mark.unit
+def test_media_file_path_different_extensions(path_manager: PathManager):
+    """Tests media_file_path with various file extensions."""
+    feed_id = "ext_test"
+    download_id = "content_item"
+
+    # Test different extensions
+    mp4_path = path_manager.media_file_path(feed_id, download_id, "mp4")
+    mkv_path = path_manager.media_file_path(feed_id, download_id, "mkv")
+    flv_path = path_manager.media_file_path(feed_id, download_id, "flv")
+
+    expected_base = path_manager.base_data_dir / feed_id
+    assert mp4_path == expected_base / "content_item.mp4"
+    assert mkv_path == expected_base / "content_item.mkv"
+    assert flv_path == expected_base / "content_item.flv"
+
+
+# --- Integration tests for URL and path consistency ---
+
+
+@pytest.mark.unit
+def test_url_path_consistency(path_manager: PathManager):
+    """Tests that URLs and file paths maintain consistent 1:1 mapping."""
+    feed_id = "consistency_test"
+    download_id = "test_video"
+    ext = "mp4"
+
+    # Get both URL and path
+    file_url = path_manager.media_file_url(feed_id, download_id, ext)
+    file_path = path_manager.media_file_path(feed_id, download_id, ext)
+
+    # URL should encode the same information as the path
+    assert feed_id in file_url
+    assert download_id in file_url
+    assert ext in file_url
+    assert feed_id in str(file_path)
+    assert download_id in str(file_path)
+    assert ext in str(file_path)
+
+
+@pytest.mark.unit
+def test_special_characters_in_identifiers(path_manager: PathManager):
+    """Tests handling of special characters in feed_id and download_id."""
+    feed_id = "feed-with_underscores"
+    download_id = "video.with.dots"
+    ext = "mp4"
+
+    # Should handle special characters without issues
+    file_path = path_manager.media_file_path(feed_id, download_id, ext)
+    file_url = path_manager.media_file_url(feed_id, download_id, ext)
+
+    assert file_path.parent.name == feed_id
+    assert file_path.name == f"{download_id}.{ext}"
+    assert feed_id in file_url
+    assert download_id in file_url
+
+
+# --- Edge cases and error handling ---
+
+
+@pytest.mark.unit
+def test_empty_feed_id_raises_error(path_manager: PathManager):
+    """Tests that empty feed_id raises ValueError."""
+    download_id = "video_123"
+    ext = "mp4"
+
+    with pytest.raises(ValueError):
+        path_manager.feed_data_dir("")
+
+    with pytest.raises(ValueError):
+        path_manager.feed_tmp_dir("")
+
+    with pytest.raises(ValueError):
+        path_manager.feed_url("")
+
+    with pytest.raises(ValueError):
+        path_manager.feed_media_url("")
+
+    with pytest.raises(ValueError):
+        path_manager.media_file_path("", download_id, ext)
+
+    with pytest.raises(ValueError):
+        path_manager.media_file_url("", download_id, ext)
+
+
+@pytest.mark.unit
+def test_whitespace_only_feed_id_raises_error(path_manager: PathManager):
+    """Tests that whitespace-only feed_id raises ValueError."""
+    download_id = "video_123"
+    ext = "mp4"
+
+    with pytest.raises(ValueError):
+        path_manager.feed_data_dir("   ")
+
+    with pytest.raises(ValueError):
+        path_manager.feed_tmp_dir("\t\n")
+
+    with pytest.raises(ValueError):
+        path_manager.feed_url(" ")
+
+    with pytest.raises(ValueError):
+        path_manager.feed_media_url("\t")
+
+    with pytest.raises(ValueError):
+        path_manager.media_file_path("  ", download_id, ext)
+
+    with pytest.raises(ValueError):
+        path_manager.media_file_url("\n", download_id, ext)
+
+
+@pytest.mark.unit
+def test_empty_download_id_raises_error(path_manager: PathManager):
+    """Tests that empty download_id raises ValueError."""
+    feed_id = "valid_feed"
+    ext = "mp4"
+
+    with pytest.raises(ValueError):
+        path_manager.media_file_path(feed_id, "", ext)
+
+    with pytest.raises(ValueError):
+        path_manager.media_file_url(feed_id, "", ext)
+
+
+@pytest.mark.unit
+def test_whitespace_only_download_id_raises_error(path_manager: PathManager):
+    """Tests that whitespace-only download_id raises ValueError."""
+    feed_id = "valid_feed"
+    ext = "mp4"
+
+    with pytest.raises(ValueError):
+        path_manager.media_file_path(feed_id, "   ", ext)
+
+    with pytest.raises(ValueError):
+        path_manager.media_file_url(feed_id, "\t\n", ext)
+
+
+@pytest.mark.unit
+def test_url_base_without_trailing_slash():
+    """Tests that base_url normalization removes trailing slashes."""
+    data_dir = Path("/tmp/data")
+    tmp_dir = Path("/tmp/tmp")
+
+    # Test various trailing slash scenarios
+    pm1 = PathManager(data_dir, tmp_dir, "http://example.com/")
+    pm2 = PathManager(data_dir, tmp_dir, "http://example.com")
+
+    assert pm1.base_url == "http://example.com"
+    assert pm2.base_url == "http://example.com"
+    assert pm1.feed_url("test") == pm2.feed_url("test")
+
+
+@pytest.mark.unit
+def test_multiple_directory_levels(path_manager: PathManager):
+    """Tests that deep directory structures work correctly."""
+    # This tests that mkdir(parents=True) works as expected
+    feed_id = "deeply/nested/feed/structure"
+
+    # Should create all necessary parent directories
+    feed_dir = path_manager.feed_data_dir(feed_id)
+    tmp_dir = path_manager.feed_tmp_dir(feed_id)
+
+    assert feed_dir.exists()
+    assert tmp_dir.exists()
+    # The full path should include all the directory levels
+    assert "deeply" in str(feed_dir)
+    assert "nested" in str(feed_dir)
+    assert "structure" in str(feed_dir)

--- a/tests/anypod/ytdlp_wrapper/test_ytdlp_wrapper.py
+++ b/tests/anypod/ytdlp_wrapper/test_ytdlp_wrapper.py
@@ -179,8 +179,8 @@ def test_download_media_to_file_success_simplified(
     )
     yt_cli_args: dict[str, Any] = {"format": "bestvideo+bestaudio/best"}
 
-    feed_temp_path = ytdlp_wrapper._app_tmp_dir / feed_id
-    feed_home_path = ytdlp_wrapper._app_data_dir / feed_id
+    feed_temp_path = ytdlp_wrapper._paths.base_tmp_dir / feed_id
+    feed_home_path = ytdlp_wrapper._paths.base_data_dir / feed_id
 
     expected_final_file = feed_home_path / f"{download_id}.{dummy_download.ext}"
 

--- a/tests/anypod/ytdlp_wrapper/test_ytdlp_wrapper.py
+++ b/tests/anypod/ytdlp_wrapper/test_ytdlp_wrapper.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from anypod.db import Download, DownloadStatus
+from anypod.path_manager import PathManager
 from anypod.ytdlp_wrapper import YtdlpWrapper
 from anypod.ytdlp_wrapper.base_handler import FetchPurpose
 from anypod.ytdlp_wrapper.youtube_handler import YoutubeHandler
@@ -30,7 +31,8 @@ def ytdlp_wrapper(
     """Fixture to provide a YtdlpWrapper instance with a mocked YoutubeHandler and temp paths."""
     app_tmp_dir = tmp_path_factory.mktemp("app_tmp")
     app_data_dir = tmp_path_factory.mktemp("app_data")
-    wrapper = YtdlpWrapper(app_tmp_dir, app_data_dir)
+    paths = PathManager(app_data_dir, app_tmp_dir, "http://localhost")
+    wrapper = YtdlpWrapper(paths)
     wrapper._source_handler = mock_youtube_handler
     return wrapper
 

--- a/tests/integration/test_integration_downloader.py
+++ b/tests/integration/test_integration_downloader.py
@@ -12,6 +12,7 @@ from anypod.data_coordinator.downloader import Downloader
 from anypod.data_coordinator.enqueuer import Enqueuer
 from anypod.db import DatabaseManager, Download, DownloadStatus
 from anypod.file_manager import FileManager
+from anypod.path_manager import PathManager
 from anypod.ytdlp_wrapper import YtdlpWrapper
 
 # Test constants - same as other integration tests for consistency
@@ -90,7 +91,13 @@ def db_manager() -> Generator[DatabaseManager]:
 def file_manager(shared_dirs: tuple[Path, Path]) -> Generator[FileManager]:
     """Provides a FileManager instance with shared data directory."""
     _, app_data_dir = shared_dirs
-    file_manager = FileManager(base_download_path=app_data_dir)
+    app_tmp_dir = shared_dirs[0]
+    paths = PathManager(
+        base_data_dir=app_data_dir,
+        base_tmp_dir=app_tmp_dir,
+        base_url="http://localhost",
+    )
+    file_manager = FileManager(paths)
     yield file_manager
 
 
@@ -98,7 +105,12 @@ def file_manager(shared_dirs: tuple[Path, Path]) -> Generator[FileManager]:
 def ytdlp_wrapper(shared_dirs: tuple[Path, Path]) -> Generator[YtdlpWrapper]:
     """Provides a YtdlpWrapper instance with shared directories."""
     app_tmp_dir, app_data_dir = shared_dirs
-    yield YtdlpWrapper(app_tmp_dir=app_tmp_dir, app_data_dir=app_data_dir)
+    paths = PathManager(
+        base_data_dir=app_data_dir,
+        base_tmp_dir=app_tmp_dir,
+        base_url="http://localhost",
+    )
+    yield YtdlpWrapper(paths)
 
 
 @pytest.fixture

--- a/tests/integration/test_integration_enqueuer.py
+++ b/tests/integration/test_integration_enqueuer.py
@@ -10,6 +10,7 @@ from anypod.config import FeedConfig
 from anypod.data_coordinator.enqueuer import Enqueuer
 from anypod.db import DatabaseManager, Download, DownloadStatus
 from anypod.exceptions import EnqueueError
+from anypod.path_manager import PathManager
 from anypod.ytdlp_wrapper import YtdlpWrapper
 
 # Test constants
@@ -74,7 +75,13 @@ def ytdlp_wrapper(tmp_path_factory: pytest.TempPathFactory) -> Generator[YtdlpWr
     app_tmp_dir = tmp_path_factory.mktemp("tmp")
     app_data_dir = tmp_path_factory.mktemp("data")
 
-    yield YtdlpWrapper(app_tmp_dir=app_tmp_dir, app_data_dir=app_data_dir)
+    paths = PathManager(
+        base_data_dir=app_data_dir,
+        base_tmp_dir=app_tmp_dir,
+        base_url="http://localhost",
+    )
+
+    yield YtdlpWrapper(paths)
 
     # Teardown: remove temporary directories
     shutil.rmtree(app_tmp_dir)

--- a/tests/integration/test_integration_pruner.py
+++ b/tests/integration/test_integration_pruner.py
@@ -1,3 +1,5 @@
+# pyright: reportPrivateUsage=false
+
 """Integration tests for Pruner with real database and file system operations."""
 
 from collections.abc import Generator
@@ -222,7 +224,7 @@ def create_dummy_file(file_manager: FileManager, download: Download) -> Path:
     Returns:
         Path to the created file.
     """
-    feed_dir = file_manager.base_download_path / download.feed
+    feed_dir = file_manager._paths.base_data_dir / download.feed
     feed_dir.mkdir(parents=True, exist_ok=True)
 
     file_name = f"{download.id}.{download.ext}"
@@ -285,8 +287,7 @@ def test_prune_feed_downloads_keep_last_success(
 
     # Verify files exist for all DOWNLOADED items
     for download in initial_downloaded:
-        file_name = f"{download.id}.{download.ext}"
-        assert file_manager.download_exists(TEST_FEED_ID, file_name)
+        assert file_manager.download_exists(TEST_FEED_ID, download.id, download.ext)
 
     # Run pruner with keep_last=2
     archived_count, files_deleted_count = pruner.prune_feed_downloads(
@@ -327,11 +328,12 @@ def test_prune_feed_downloads_keep_last_success(
     # Verify files were deleted for pruned DOWNLOADED items
     kept_downloaded_ids = {dl.id for dl in most_recent_downloaded}
     for download in initial_downloaded:
-        file_name = f"{download.id}.{download.ext}"
         if download.id in kept_downloaded_ids:
-            assert file_manager.download_exists(TEST_FEED_ID, file_name)
+            assert file_manager.download_exists(TEST_FEED_ID, download.id, download.ext)
         else:
-            assert not file_manager.download_exists(TEST_FEED_ID, file_name)
+            assert not file_manager.download_exists(
+                TEST_FEED_ID, download.id, download.ext
+            )
 
     # Verify archived downloads increased
     archived_downloads = db_manager.get_downloads_by_status(
@@ -400,8 +402,7 @@ def test_prune_feed_downloads_since_date_success(
 
     # Verify files exist for remaining downloads
     for download in remaining_downloaded:
-        file_name = f"{download.id}.{download.ext}"
-        assert file_manager.download_exists(TEST_FEED_ID, file_name)
+        assert file_manager.download_exists(TEST_FEED_ID, download.id, download.ext)
 
     # Verify SKIPPED items were not affected (should still be SKIPPED)
     skipped_downloads = db_manager.get_downloads_by_status(
@@ -503,11 +504,14 @@ def test_prune_feed_downloads_missing_files(
         for dl in populated_test_data
         if dl.status == DownloadStatus.DOWNLOADED and dl.id == "downloaded_old_1"
     )
-    file_name = f"{missing_download.id}.{missing_download.ext}"
-    file_manager.delete_download_file(TEST_FEED_ID, file_name)
+    file_manager.delete_download_file(
+        TEST_FEED_ID, missing_download.id, missing_download.ext
+    )
 
     # Verify file is gone
-    assert not file_manager.download_exists(TEST_FEED_ID, file_name)
+    assert not file_manager.download_exists(
+        TEST_FEED_ID, missing_download.id, missing_download.ext
+    )
 
     # Run pruner to remove old items
     archived_count, files_deleted_count = pruner.prune_feed_downloads(
@@ -672,7 +676,7 @@ def test_prune_feed_downloads_large_dataset(
 
     finally:
         # Cleanup: remove any remaining files
-        feed_dir = file_manager.base_download_path / feed_id
+        feed_dir = file_manager._paths.base_data_dir / feed_id
         if feed_dir.exists():
             shutil.rmtree(feed_dir)
 

--- a/tests/integration/test_integration_pruner.py
+++ b/tests/integration/test_integration_pruner.py
@@ -10,6 +10,7 @@ import pytest
 from anypod.data_coordinator.pruner import Pruner
 from anypod.db import DatabaseManager, Download, DownloadStatus
 from anypod.file_manager import FileManager
+from anypod.path_manager import PathManager
 
 # Test data constants
 TEST_FEED_ID = "test_feed"
@@ -195,7 +196,13 @@ def db_manager() -> Generator[DatabaseManager]:
 def file_manager(shared_dirs: tuple[Path, Path]) -> Generator[FileManager]:
     """Provides a FileManager instance with shared data directory."""
     _, app_data_dir = shared_dirs
-    file_manager = FileManager(base_download_path=app_data_dir)
+    app_tmp_dir = shared_dirs[0]
+    paths = PathManager(
+        base_data_dir=app_data_dir,
+        base_tmp_dir=app_tmp_dir,
+        base_url="http://localhost",
+    )
+    file_manager = FileManager(paths)
     yield file_manager
 
 

--- a/tests/integration/test_integration_ytdlp_wrapper.py
+++ b/tests/integration/test_integration_ytdlp_wrapper.py
@@ -8,6 +8,7 @@ import pytest
 
 from anypod.db import Download, DownloadStatus
 from anypod.exceptions import YtdlpApiError
+from anypod.path_manager import PathManager
 from anypod.ytdlp_wrapper import YtdlpWrapper
 from anypod.ytdlp_wrapper.ytdlp_core import YtdlpCore
 
@@ -63,7 +64,13 @@ def ytdlp_wrapper(tmp_path_factory: pytest.TempPathFactory) -> Generator[YtdlpWr
     app_tmp_dir = tmp_path_factory.mktemp("tmp")
     app_data_dir = tmp_path_factory.mktemp("data")
 
-    yield YtdlpWrapper(app_tmp_dir=app_tmp_dir, app_data_dir=app_data_dir)
+    paths = PathManager(
+        base_data_dir=app_data_dir,
+        base_tmp_dir=app_tmp_dir,
+        base_url="http://localhost",
+    )
+
+    yield YtdlpWrapper(paths)
 
     # Teardown: remove temporary directories
     shutil.rmtree(app_tmp_dir)


### PR DESCRIPTION
## Summary
- add `PathManager` for consistent path and URL generation
- refactor FileManager, YtdlpWrapper and RSS generation to use `PathManager`
- adjust CLI helpers and tests for new interface

## Testing
- `pre-commit run --files src/anypod/path_manager.py src/anypod/__init__.py src/anypod/cli/debug_downloader.py src/anypod/cli/debug_enqueuer.py src/anypod/cli/debug_ytdlp.py src/anypod/file_manager.py src/anypod/rss/feedgen_core.py src/anypod/rss/rss_feed.py src/anypod/ytdlp_wrapper/ytdlp_wrapper.py tests/anypod/test_file_manager.py tests/anypod/test_rss_feed.py tests/anypod/ytdlp_wrapper/test_ytdlp_wrapper.py tests/integration/test_integration_downloader.py tests/integration/test_integration_enqueuer.py tests/integration/test_integration_pruner.py tests/integration/test_integration_ytdlp_wrapper.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845f3e27614832aafbc57f215b33342