### PR TITLE
Group data classes under types packages

### DIFF
--- a/src/anypod/cli/debug_downloader.py
+++ b/src/anypod/cli/debug_downloader.py
@@ -13,8 +13,7 @@ from pathlib import Path
 from ..config import AppSettings
 from ..data_coordinator.downloader import Downloader
 from ..db import DownloadDatabase
-from ..db.download import Download
-from ..db.download_status import DownloadStatus
+from ..db.types import Download, DownloadStatus
 from ..exceptions import DatabaseOperationError, DownloadError
 from ..file_manager import FileManager
 from ..path_manager import PathManager

--- a/src/anypod/cli/debug_enqueuer.py
+++ b/src/anypod/cli/debug_enqueuer.py
@@ -10,7 +10,8 @@ from pathlib import Path
 
 from ..config import AppSettings
 from ..data_coordinator.enqueuer import Enqueuer
-from ..db import Download, DownloadDatabase, DownloadStatus, FeedDatabase
+from ..db import DownloadDatabase, FeedDatabase
+from ..db.types import Download, DownloadStatus
 from ..exceptions import DatabaseOperationError, EnqueueError
 from ..path_manager import PathManager
 from ..ytdlp_wrapper import YtdlpWrapper

--- a/src/anypod/cli/debug_ytdlp.py
+++ b/src/anypod/cli/debug_ytdlp.py
@@ -11,7 +11,7 @@ import sys
 
 import yaml
 
-from ..db.download_status import DownloadStatus
+from ..db.types import DownloadStatus
 from ..exceptions import YtdlpApiError
 from ..path_manager import PathManager
 from ..ytdlp_wrapper import YtdlpWrapper

--- a/src/anypod/config/__init__.py
+++ b/src/anypod/config/__init__.py
@@ -1,16 +1,8 @@
 from .config import AppSettings, DebugMode
-from .feed_config import (
-    FeedConfig,
-    FeedMetadataOverrides,
-)
-from .podcast_categories import PodcastCategories
-from .podcast_explicit import PodcastExplicit
+from .feed_config import FeedConfig
 
 __all__ = [
     "AppSettings",
     "DebugMode",
     "FeedConfig",
-    "FeedMetadataOverrides",
-    "PodcastCategories",
-    "PodcastExplicit",
 ]

--- a/src/anypod/config/feed_config.py
+++ b/src/anypod/config/feed_config.py
@@ -12,38 +12,7 @@ from typing import Any
 from pydantic import BaseModel, Field, field_validator
 
 from ..ytdlp_wrapper.ytdlp_core import YtdlpCore
-from .podcast_categories import PodcastCategories
-from .podcast_explicit import PodcastExplicit
-
-
-class FeedMetadataOverrides(BaseModel):
-    """Podcast metadata overrides for RSS feed generation.
-
-    These values can be specified in the feed configuration to override
-    metadata that would otherwise be extracted from the yt-dlp output.
-    If not specified here, the system will attempt to extract these
-    values from the source content where possible (e.g., channel name
-    as title, channel description as description).
-
-    All fields are optional to allow selective overrides.
-    """
-
-    title: str | None = Field(None, description="Podcast title")
-    subtitle: str | None = Field(None, description="Podcast subtitle")
-    description: str | None = Field(None, description="Podcast description")
-    language: str | None = Field(
-        None, description="Podcast language (e.g., 'en', 'es')"
-    )
-    categories: PodcastCategories = Field(
-        default_factory=PodcastCategories,
-        description="Apple Podcasts category/categories (max 2)",
-    )
-    explicit: PodcastExplicit | None = Field(None, description="Explicit content flag")
-    image_url: str | None = Field(
-        None,
-        description="Podcast image URL, must be at least 1400x1400px, ideally 3000x3000px",
-    )
-    author: str | None = Field(None, description="Podcast author")
+from .types import FeedMetadataOverrides
 
 
 class FeedConfig(BaseModel):

--- a/src/anypod/config/types/__init__.py
+++ b/src/anypod/config/types/__init__.py
@@ -1,0 +1,11 @@
+"""Aggregated config data types."""
+
+from .feed_metadata_overrides import FeedMetadataOverrides
+from .podcast_categories import PodcastCategories
+from .podcast_explicit import PodcastExplicit
+
+__all__ = [
+    "FeedMetadataOverrides",
+    "PodcastCategories",
+    "PodcastExplicit",
+]

--- a/src/anypod/config/types/feed_metadata_overrides.py
+++ b/src/anypod/config/types/feed_metadata_overrides.py
@@ -1,0 +1,27 @@
+"""Pydantic model for overriding feed metadata in RSS generation."""
+
+from pydantic import BaseModel, Field
+
+from .podcast_categories import PodcastCategories
+from .podcast_explicit import PodcastExplicit
+
+
+class FeedMetadataOverrides(BaseModel):
+    """Podcast metadata overrides for RSS feed generation."""
+
+    title: str | None = Field(None, description="Podcast title")
+    subtitle: str | None = Field(None, description="Podcast subtitle")
+    description: str | None = Field(None, description="Podcast description")
+    language: str | None = Field(
+        None, description="Podcast language (e.g., 'en', 'es')"
+    )
+    categories: PodcastCategories = Field(
+        default_factory=PodcastCategories,
+        description="Apple Podcasts category/categories (max 2)",
+    )
+    explicit: PodcastExplicit | None = Field(None, description="Explicit content flag")
+    image_url: str | None = Field(
+        None,
+        description="Podcast image URL, must be at least 1400x1400px, ideally 3000x3000px",
+    )
+    author: str | None = Field(None, description="Podcast author")

--- a/src/anypod/config/types/podcast_categories.py
+++ b/src/anypod/config/types/podcast_categories.py
@@ -1,10 +1,12 @@
+"""Apple Podcast category handling utilities."""
+
 import html
 from typing import Any, ClassVar
 
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import CoreSchema, core_schema
 
-from ..db.sqlite_utils_core import register_adapter
+from ...db.sqlite_utils_core import register_adapter
 
 
 class PodcastCategories:

--- a/src/anypod/config/types/podcast_explicit.py
+++ b/src/anypod/config/types/podcast_explicit.py
@@ -1,10 +1,12 @@
+"""Podcast explicit content flags."""
+
 from enum import Enum
 from typing import Any
 
 from pydantic import GetCoreSchemaHandler
 from pydantic_core import CoreSchema, core_schema
 
-from ..db.sqlite_utils_core import register_adapter
+from ...db.sqlite_utils_core import register_adapter
 
 
 class PodcastExplicit(str, Enum):

--- a/src/anypod/data_coordinator/downloader.py
+++ b/src/anypod/data_coordinator/downloader.py
@@ -11,9 +11,8 @@ from pathlib import Path
 from typing import Any
 
 from ..config import FeedConfig
-from ..db.download import Download
 from ..db.download_db import DownloadDatabase
-from ..db.download_status import DownloadStatus
+from ..db.types import Download, DownloadStatus
 from ..exceptions import (
     DatabaseOperationError,
     DownloadError,

--- a/src/anypod/data_coordinator/enqueuer.py
+++ b/src/anypod/data_coordinator/enqueuer.py
@@ -11,9 +11,8 @@ from typing import Any
 
 from ..config import FeedConfig
 from ..db import DownloadDatabase
-from ..db.download import Download
-from ..db.download_status import DownloadStatus
 from ..db.feed_db import FeedDatabase
+from ..db.types import Download, DownloadStatus
 from ..exceptions import (
     DatabaseOperationError,
     DownloadNotFoundError,

--- a/src/anypod/data_coordinator/pruner.py
+++ b/src/anypod/data_coordinator/pruner.py
@@ -10,8 +10,7 @@ import logging
 from typing import Any
 
 from ..db import DownloadDatabase
-from ..db.download import Download
-from ..db.download_status import DownloadStatus
+from ..db.types import Download, DownloadStatus
 from ..exceptions import (
     DatabaseOperationError,
     DownloadNotFoundError,

--- a/src/anypod/db/download_db.py
+++ b/src/anypod/db/download_db.py
@@ -11,9 +11,8 @@ import logging
 from pathlib import Path
 
 from ..exceptions import DatabaseOperationError, DownloadNotFoundError, NotFoundError
-from .download import Download
-from .download_status import DownloadStatus
 from .sqlite_utils_core import SqliteUtilsCore
+from .types import Download, DownloadStatus
 
 logger = logging.getLogger(__name__)
 

--- a/src/anypod/db/feed_db.py
+++ b/src/anypod/db/feed_db.py
@@ -11,8 +11,8 @@ from pathlib import Path
 from typing import Any
 
 from ..exceptions import DatabaseOperationError, FeedNotFoundError, NotFoundError
-from .feed import Feed
 from .sqlite_utils_core import SqliteUtilsCore
+from .types import Feed
 
 logger = logging.getLogger(__name__)
 

--- a/src/anypod/db/types/__init__.py
+++ b/src/anypod/db/types/__init__.py
@@ -1,0 +1,13 @@
+"""Database model and enum types."""
+
+from .download import Download
+from .download_status import DownloadStatus
+from .feed import Feed
+from .source_type import SourceType
+
+__all__ = [
+    "Download",
+    "DownloadStatus",
+    "Feed",
+    "SourceType",
+]

--- a/src/anypod/db/types/download.py
+++ b/src/anypod/db/types/download.py
@@ -1,8 +1,10 @@
+"""Data model representing a downloadable item."""
+
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
-from .base_db import parse_datetime, parse_required_datetime
+from ..base_db import parse_datetime, parse_required_datetime
 from .download_status import DownloadStatus
 
 

--- a/src/anypod/db/types/download_status.py
+++ b/src/anypod/db/types/download_status.py
@@ -1,6 +1,8 @@
+"""Download status lifecycle values."""
+
 from enum import Enum
 
-from .sqlite_utils_core import register_adapter
+from ..sqlite_utils_core import register_adapter
 
 
 class DownloadStatus(Enum):

--- a/src/anypod/db/types/feed.py
+++ b/src/anypod/db/types/feed.py
@@ -1,10 +1,11 @@
+"""Data model representing a feed."""
+
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
-from ..config.podcast_categories import PodcastCategories
-from ..config.podcast_explicit import PodcastExplicit
-from .base_db import parse_datetime, parse_required_datetime
+from ...config.types import PodcastCategories, PodcastExplicit
+from ..base_db import parse_datetime, parse_required_datetime
 from .source_type import SourceType
 
 

--- a/src/anypod/db/types/source_type.py
+++ b/src/anypod/db/types/source_type.py
@@ -1,6 +1,8 @@
+"""Enumeration of feed source types."""
+
 from enum import Enum
 
-from .sqlite_utils_core import register_adapter
+from ..sqlite_utils_core import register_adapter
 
 
 class SourceType(Enum):

--- a/src/anypod/rss/feedgen_core.py
+++ b/src/anypod/rss/feedgen_core.py
@@ -9,7 +9,7 @@ from Anypod download data.
 from feedgen.feed import FeedGenerator  # type: ignore
 
 from anypod.config import FeedConfig
-from anypod.db.download import Download
+from anypod.db.types import Download
 from anypod.exceptions import RSSGenerationError
 from anypod.path_manager import PathManager
 

--- a/src/anypod/rss/rss_feed.py
+++ b/src/anypod/rss/rss_feed.py
@@ -13,8 +13,7 @@ from anypod.rss.feedgen_core import FeedgenCore
 
 from ..config import FeedConfig
 from ..db import DownloadDatabase
-from ..db.download import Download
-from ..db.download_status import DownloadStatus
+from ..db.types import Download, DownloadStatus
 from ..exceptions import DatabaseOperationError, RSSGenerationError
 from ..path_manager import PathManager
 

--- a/src/anypod/ytdlp_wrapper/base_handler.py
+++ b/src/anypod/ytdlp_wrapper/base_handler.py
@@ -9,8 +9,7 @@ from collections.abc import Callable
 from enum import Enum
 from typing import Any, Protocol
 
-from ..db.download import Download
-from ..db.feed import Feed
+from ..db.types import Download, Feed
 from .ytdlp_core import YtdlpInfo
 
 

--- a/src/anypod/ytdlp_wrapper/youtube_handler.py
+++ b/src/anypod/ytdlp_wrapper/youtube_handler.py
@@ -12,10 +12,7 @@ import logging
 import mimetypes
 from typing import Any
 
-from ..db.download import Download
-from ..db.download_status import DownloadStatus
-from ..db.feed import Feed
-from ..db.source_type import SourceType
+from ..db.types import Download, DownloadStatus, Feed, SourceType
 from ..exceptions import (
     YtdlpDataError,
     YtdlpFieldInvalidError,

--- a/src/anypod/ytdlp_wrapper/ytdlp_wrapper.py
+++ b/src/anypod/ytdlp_wrapper/ytdlp_wrapper.py
@@ -9,8 +9,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from ..db.download import Download
-from ..db.feed import Feed
+from ..db.types import Download, Feed
 from ..exceptions import YtdlpApiError
 from ..path_manager import PathManager
 from .base_handler import FetchPurpose, ReferenceType, SourceHandlerBase

--- a/tests/anypod/data_coordinator/test_downloader.py
+++ b/tests/anypod/data_coordinator/test_downloader.py
@@ -14,13 +14,11 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from anypod.config import FeedConfig, FeedMetadataOverrides
+from anypod.config import FeedConfig
+from anypod.config.types import FeedMetadataOverrides
 from anypod.data_coordinator.downloader import Downloader
 from anypod.db import DownloadDatabase
-from anypod.db.download import Download
-from anypod.db.download_status import DownloadStatus
-from anypod.db.feed import Feed
-from anypod.db.source_type import SourceType
+from anypod.db.types import Download, DownloadStatus, Feed, SourceType
 from anypod.exceptions import (
     DatabaseOperationError,
     DownloadError,

--- a/tests/anypod/data_coordinator/test_enqueuer.py
+++ b/tests/anypod/data_coordinator/test_enqueuer.py
@@ -10,10 +10,7 @@ import pytest
 from anypod.config import FeedConfig
 from anypod.data_coordinator.enqueuer import Enqueuer
 from anypod.db import DownloadDatabase, FeedDatabase
-from anypod.db.download import Download
-from anypod.db.download_status import DownloadStatus
-from anypod.db.feed import Feed
-from anypod.db.source_type import SourceType
+from anypod.db.types import Download, DownloadStatus, Feed, SourceType
 from anypod.exceptions import (
     DatabaseOperationError,
     DownloadNotFoundError,

--- a/tests/anypod/data_coordinator/test_pruner.py
+++ b/tests/anypod/data_coordinator/test_pruner.py
@@ -15,8 +15,7 @@ import pytest
 
 from anypod.data_coordinator.pruner import Pruner
 from anypod.db import DownloadDatabase
-from anypod.db.download import Download
-from anypod.db.download_status import DownloadStatus
+from anypod.db.types import Download, DownloadStatus
 from anypod.exceptions import (
     DatabaseOperationError,
     DownloadNotFoundError,

--- a/tests/anypod/db/test_download_db.py
+++ b/tests/anypod/db/test_download_db.py
@@ -10,8 +10,7 @@ from typing import Any
 import pytest
 
 from anypod.db import DownloadDatabase
-from anypod.db.download import Download
-from anypod.db.download_status import DownloadStatus
+from anypod.db.types import Download, DownloadStatus
 from anypod.exceptions import DatabaseOperationError, DownloadNotFoundError
 
 # --- Fixtures ---

--- a/tests/anypod/db/test_feed_db.py
+++ b/tests/anypod/db/test_feed_db.py
@@ -11,8 +11,7 @@ from typing import Any
 import pytest
 
 from anypod.db import FeedDatabase
-from anypod.db.feed import Feed
-from anypod.db.source_type import SourceType
+from anypod.db.types import Feed, SourceType
 from anypod.exceptions import FeedNotFoundError
 
 # --- Fixtures ---

--- a/tests/anypod/test_rss_feed.py
+++ b/tests/anypod/test_rss_feed.py
@@ -9,15 +9,14 @@ from xml.etree import ElementTree as ET
 
 import pytest
 
-from anypod.config import (
-    FeedConfig,
+from anypod.config import FeedConfig
+from anypod.config.types import (
     FeedMetadataOverrides,
     PodcastCategories,
     PodcastExplicit,
 )
 from anypod.db import DownloadDatabase
-from anypod.db.download import Download
-from anypod.db.download_status import DownloadStatus
+from anypod.db.types import Download, DownloadStatus
 from anypod.exceptions import DatabaseOperationError, RSSGenerationError
 from anypod.path_manager import PathManager
 from anypod.rss.rss_feed import RSSFeedGenerator

--- a/tests/anypod/ytdlp_wrapper/test_youtube_handler.py
+++ b/tests/anypod/ytdlp_wrapper/test_youtube_handler.py
@@ -8,9 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from anypod.db.download import Download
-from anypod.db.download_status import DownloadStatus
-from anypod.db.source_type import SourceType
+from anypod.db.types import Download, DownloadStatus, SourceType
 from anypod.ytdlp_wrapper.base_handler import FetchPurpose
 from anypod.ytdlp_wrapper.youtube_handler import (
     ReferenceType,

--- a/tests/anypod/ytdlp_wrapper/test_ytdlp_wrapper.py
+++ b/tests/anypod/ytdlp_wrapper/test_ytdlp_wrapper.py
@@ -9,10 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from anypod.db.download import Download
-from anypod.db.download_status import DownloadStatus
-from anypod.db.feed import Feed
-from anypod.db.source_type import SourceType
+from anypod.db.types import Download, DownloadStatus, Feed, SourceType
 from anypod.path_manager import PathManager
 from anypod.ytdlp_wrapper import YtdlpWrapper
 from anypod.ytdlp_wrapper.base_handler import FetchPurpose, ReferenceType

--- a/tests/integration/test_integration_downloader.py
+++ b/tests/integration/test_integration_downloader.py
@@ -13,9 +13,8 @@ from anypod.config import FeedConfig
 from anypod.data_coordinator.downloader import Downloader
 from anypod.data_coordinator.enqueuer import Enqueuer
 from anypod.db import DownloadDatabase
-from anypod.db.download import Download
-from anypod.db.download_status import DownloadStatus
 from anypod.db.feed_db import FeedDatabase
+from anypod.db.types import Download, DownloadStatus
 from anypod.file_manager import FileManager
 from anypod.path_manager import PathManager
 from anypod.ytdlp_wrapper import YtdlpWrapper

--- a/tests/integration/test_integration_enqueuer.py
+++ b/tests/integration/test_integration_enqueuer.py
@@ -9,9 +9,8 @@ import pytest
 from anypod.config import FeedConfig
 from anypod.data_coordinator.enqueuer import Enqueuer
 from anypod.db import DownloadDatabase
-from anypod.db.download import Download
-from anypod.db.download_status import DownloadStatus
 from anypod.db.feed_db import FeedDatabase
+from anypod.db.types import Download, DownloadStatus
 from anypod.exceptions import EnqueueError
 from anypod.path_manager import PathManager
 from anypod.ytdlp_wrapper import YtdlpWrapper

--- a/tests/integration/test_integration_pruner.py
+++ b/tests/integration/test_integration_pruner.py
@@ -11,8 +11,7 @@ import pytest
 
 from anypod.data_coordinator.pruner import Pruner
 from anypod.db import DownloadDatabase
-from anypod.db.download import Download
-from anypod.db.download_status import DownloadStatus
+from anypod.db.types import Download, DownloadStatus
 from anypod.file_manager import FileManager
 from anypod.path_manager import PathManager
 

--- a/tests/integration/test_integration_ytdlp_wrapper.py
+++ b/tests/integration/test_integration_ytdlp_wrapper.py
@@ -6,9 +6,7 @@ import shutil
 
 import pytest
 
-from anypod.db.download import Download
-from anypod.db.download_status import DownloadStatus
-from anypod.db.source_type import SourceType
+from anypod.db.types import Download, DownloadStatus, SourceType
 from anypod.exceptions import YtdlpApiError
 from anypod.path_manager import PathManager
 from anypod.ytdlp_wrapper import YtdlpWrapper


### PR DESCRIPTION
## Summary
- reorganize `config` and `db` data classes into `types` subpackages
- update imports to use the new aggregated modules
- add missing file docstrings
- adjust tests for new import paths

## Testing
- `uv run pre-commit run --files src/anypod/cli/debug_downloader.py src/anypod/cli/debug_ytdlp.py src/anypod/config/__init__.py src/anypod/config/feed_config.py src/anypod/config/types/podcast_categories.py src/anypod/config/types/podcast_explicit.py src/anypod/config/types/feed_metadata_overrides.py src/anypod/config/types/__init__.py src/anypod/data_coordinator/downloader.py src/anypod/data_coordinator/enqueuer.py src/anypod/data_coordinator/pruner.py src/anypod/db/__init__.py src/anypod/db/download_db.py src/anypod/db/feed_db.py src/anypod/db/types/download.py src/anypod/db/types/download_status.py src/anypod/db/types/feed.py src/anypod/db/types/source_type.py src/anypod/db/types/__init__.py src/anypod/rss/feedgen_core.py src/anypod/rss/rss_feed.py src/anypod/ytdlp_wrapper/base_handler.py src/anypod/ytdlp_wrapper/youtube_handler.py src/anypod/ytdlp_wrapper/ytdlp_wrapper.py tests/anypod/data_coordinator/test_downloader.py tests/anypod/data_coordinator/test_enqueuer.py tests/anypod/data_coordinator/test_pruner.py tests/anypod/db/test_download_db.py tests/anypod/db/test_feed_db.py tests/anypod/test_rss_feed.py tests/anypod/ytdlp_wrapper/test_youtube_handler.py tests/anypod/ytdlp_wrapper/test_ytdlp_wrapper.py tests/integration/test_integration_downloader.py tests/integration/test_integration_enqueuer.py tests/integration/test_integration_pruner.py tests/integration/test_integration_ytdlp_wrapper.py`
- `uv run pytest -q`
- `uv run pytest --integration -q` *(fails: yt-dlp blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6848ad6816e4832a8532a9277b70311a