### PR TITLE
feat: Add Patreon source support with handler-based architecture

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,5 +1,6 @@
 ---
 description: Create a pull request from the current branch
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git branch:*), Bash(git log:*), Bash(git rev-parse:*)
 ---
 
 ## Context

--- a/.claude/commands/prd.md
+++ b/.claude/commands/prd.md
@@ -1,0 +1,53 @@
+---
+description: Plan and implement a feature (PRD workflow)
+---
+
+## Context
+
+- Read project guardrails and architecture first:
+  - @DESIGN_DOC.md
+  - @README.md
+
+## Your task
+
+Follow a Gather → Plan → Act workflow to deliver a focused feature.
+
+1) Gather all context necessary for implementation
+- Inspect relevant code paths for the feature area
+- Understand prior art, existing code patterns, structures, and organization
+- Identify caveats, missing information, assumptions
+
+2) Plan
+- Draft a short design in `docs/designs/` named `NN-<feature>.md` with:
+  - existing designs (you don't have to read them, but know they are there): !`ls docs/designs/`
+  - Problem/goal, assumptions, constraints
+  - Impacted modules and minimal changes
+  - Step-by-step implementation plan and test plan
+    - For each actionable step/code change, use a md task: `- [ ]`
+- Stop here and request review/approval before coding.
+
+3) Act (after approval)
+- Implement only the approved scope. Keep changes small and cohesive.
+- Add/adjust unit tests as you implement each feature; don't move on to a new feature until the existing one has test coverage
+  - Make sure to run the new/adjusted tests to ensure they pass
+- Check off each item as you complete them: `- [x]`
+- Update docs/examples if behavior or configuration changed.
+
+5) Handoff
+- Summarize changes, notable decisions, and next steps.
+
+### Deliverables
+
+- Design doc in `docs/designs/NN-<feature>.md` (gather + plan)
+- Focused implementation and tests (act)
+- Passing lint, type check, and tests (validate)
+- Brief summary with file references (handoff)
+
+### Notes
+
+- Keep the surface area minimal; align with existing code patterns in the code base
+- Ask for clarification if the scope is ambiguous.
+
+## Feature Details
+
+$ARGUMENTS

--- a/.cursor/rules/claude-project-rules.mdc
+++ b/.cursor/rules/claude-project-rules.mdc
@@ -213,6 +213,8 @@ anypod/
 │   │       ├── info.py          # yt-dlp info parser
 │   │       └── thumbnails.py    # yt-dlp thumbnail parser
 │   ├── exceptions.py            # Custom exceptions
+│   ├── ffmpeg.py                # FFmpeg wrapper for media processing
+│   ├── ffprobe.py               # FFprobe wrapper for media metadata
 │   ├── file_manager.py          # File operations abstraction
 │   ├── image_downloader.py      # Image downloading for feeds/thumbnails
 │   ├── logging_config.py        # Logging configuration

--- a/.cursor/rules/claude-project-rules.mdc
+++ b/.cursor/rules/claude-project-rules.mdc
@@ -139,6 +139,7 @@ Download status transitions are implemented as explicit methods, not generic upd
 - Logging: Structured JSON logging with proper context propagation
 - Database: Uses `SQLModel` and `SQLAlchemy` with a custom `SqlalchemyCore` class, not raw SQLite.
 - Currently synchronous but designed for future async conversion
+- Function signatures: Default to required parameters; avoid annotating arguments as ``<type> | None`` unless ``None`` is a real, supported input path.
 
 ### Tool Configuration
 - Linting and formatting: ruff configuration in @pyproject.toml
@@ -204,7 +205,8 @@ anypod/
   │   │       └── static.py        # Static file serving and directory browsing
   │   │       └── admin.py         # Admin-only endpoints (served on private admin server)
 │   ├── ytdlp_wrapper/           # `yt-dlp` integration
-│   │   ├── base_handler.py      # Base handler interface for different source types
+│   │   ├── base_handler.py      # Base handler interface and selector for different source types
+│   │   ├── patreon_handler.py   # Patreon source handler
 │   │   ├── youtube_handler.py   # YouTube source handler
 │   │   ├── ytdlp_wrapper.py     # High-level wrapper
 │   │   └── core/                # Core yt-dlp wrapper

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,5 @@
 {
-    "python.testing.pytestArgs": [
-        "tests",
-        "--integration",
-        "--no-cov"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+  "python.testing.pytestArgs": ["tests", "--integration", "--no-cov"],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,8 @@ anypod/
 │   │       ├── info.py          # yt-dlp info parser
 │   │       └── thumbnails.py    # yt-dlp thumbnail parser
 │   ├── exceptions.py            # Custom exceptions
+│   ├── ffmpeg.py                # FFmpeg wrapper for media processing
+│   ├── ffprobe.py               # FFprobe wrapper for media metadata
 │   ├── file_manager.py          # File operations abstraction
 │   ├── image_downloader.py      # Image downloading for feeds/thumbnails
 │   ├── logging_config.py        # Logging configuration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ Download status transitions are implemented as explicit methods, not generic upd
 - Logging: Structured JSON logging with proper context propagation
 - Database: Uses `SQLModel` and `SQLAlchemy` with a custom `SqlalchemyCore` class, not raw SQLite.
 - Currently synchronous but designed for future async conversion
+- Function signatures: Default to required parameters; avoid annotating arguments as ``<type> | None`` unless ``None`` is a real, supported input path.
 
 ### Tool Configuration
 - Linting and formatting: ruff configuration in @pyproject.toml
@@ -198,7 +199,8 @@ anypod/
   │   │       └── static.py        # Static file serving and directory browsing
   │   │       └── admin.py         # Admin-only endpoints (served on private admin server)
 │   ├── ytdlp_wrapper/           # `yt-dlp` integration
-│   │   ├── base_handler.py      # Base handler interface for different source types
+│   │   ├── base_handler.py      # Base handler interface and selector for different source types
+│   │   ├── patreon_handler.py   # Patreon source handler
 │   │   ├── youtube_handler.py   # YouTube source handler
 │   │   ├── ytdlp_wrapper.py     # High-level wrapper
 │   │   └── core/                # Core yt-dlp wrapper

--- a/DESIGN_DOC.md
+++ b/DESIGN_DOC.md
@@ -543,6 +543,7 @@ All CLI flags can alternatively be set via environment variables using uppercase
 ## Dependencies & Tooling
 * **Package Management:** **uv** with `pyproject.toml` + `uv.lock` for reproducible builds
 * **Core Dependencies:** pydantic, SQLModel, SQLAlchemy, feedgen, yt-dlp (pinned to minimum version), APScheduler
+* **System Dependencies:** ffmpeg and ffprobe (for image format detection and conversion)
 * **Development Tools:** ruff (linting/formatting), pyright (type checking), pytest ecosystem (testing), pre-commit (git hooks)
 
 ---

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ I recommend using a filter (either `since` or `keep_last`) when setting up your 
 
 ## Development
 
-Requirements: Python 3.13+, [`uv`](https://docs.astral.sh/uv/) package manager.
+Requirements: Python 3.13+, [`uv`](https://docs.astral.sh/uv/) package manager, ffmpeg and ffprobe.
 
 ```bash
 # Install deps

--- a/README.md
+++ b/README.md
@@ -9,20 +9,30 @@ Your self-hosted, YAML-driven bridge from yt-dlp–supported sources (YouTube ch
 
 ## Table of contents
 
-- [High Level](#high-level)
-- [Features](#features)
-- [Quick start](#quick-start)
-- [Configuration](#configuration)
-- [Environment variables](#environment-variables)
-- [HTTP endpoints](#http-endpoints)
-- [Reverse proxies](#reverse-proxies)
-- [Limitations and notes](#limitations-and-notes)
-- [Development](#development)
-- [Architecture](#architecture)
-- [Roadmap](#roadmap)
-- [FAQ / Troubleshooting](#faq--troubleshooting)
-- [License](#license)
-- [Acknowledgements](#acknowledgements)
+- [Anypod](#anypod)
+  - [Table of contents](#table-of-contents)
+  - [High Level](#high-level)
+  - [Features](#features)
+  - [Quick start](#quick-start)
+    - [Using Docker Compose (recommended)](#using-docker-compose-recommended)
+    - [Using Docker directly](#using-docker-directly)
+  - [Configuration](#configuration)
+  - [Environment variables](#environment-variables)
+  - [HTTP endpoints](#http-endpoints)
+    - [Public endpoints](#public-endpoints)
+    - [Admin endpoints (trusted/local access only)](#admin-endpoints-trustedlocal-access-only)
+  - [Reverse proxies](#reverse-proxies)
+  - [Limitations and Notes](#limitations-and-notes)
+    - [Scheduling and Rate Limiting](#scheduling-and-rate-limiting)
+    - [Cookies](#cookies)
+    - [PO Tokens (YouTube)](#po-tokens-youtube)
+    - [Pocket Casts](#pocket-casts)
+    - [Filtering](#filtering)
+    - [Patreon (Beta)](#patreon-beta)
+  - [Development](#development)
+  - [Architecture](#architecture)
+  - [Roadmap](#roadmap)
+  - [FAQ / Troubleshooting](#faq--troubleshooting)
 
 
 ## High Level
@@ -37,7 +47,7 @@ Anypod is a thin Python wrapper around `yt‑dlp` that turns any `yt‑dlp`–su
 ## Features
 
 - Simple YAML config with per‑feed schedules
-- Works with YouTube channels and playlists
+- Works with YouTube channels and playlists, Patreon creator pages and posts (beta)
 - Feed metadata overrides (title, description, artwork, categories, explicit, etc.)
 - Thumbnail hosting: Downloads and serves feed artwork and episode thumbnails locally
 - Retention policies: keep the last N items and/or only since YYYYMMDD
@@ -172,21 +182,21 @@ Reserved/managed `yt‑dlp` options (set by Anypod, do not override):
 
 All can be provided via env or CLI flags (kebab‑case). Common ones:
 
-| Name | Default | Description |
-| ---- | ------- | ----------- |
-| `BASE_URL` | `http://reverseproxy.example:8024` | Public base URL for feed/media links (set this behind a reverse proxy) |
-| `SERVER_PORT` | `8024` | Bind port for public server |
-| `ADMIN_SERVER_PORT` | `8025` | Bind port for admin server (should not be exposed publicly) |
-| `TRUSTED_PROXIES` | unset | List of local IPs or networks allowed to access the server, mainly for reverse proxy use (e.g. `["192.168.1.0/24"]`) |
-| `TZ` | unset | Your timezone (set if you don't want to mount `/etc/localtime`) |
-| `LOG_FORMAT` | `json` | `human` or `json` |
-| `LOG_LEVEL` | `INFO` | Log level |
-| `LOG_INCLUDE_STACKTRACE` | `false` | Include stack traces in error logs |
-| `POT_PROVIDER_URL` | unset | Base URL for a bgutil POT provider. When set, yt-dlp will be configured to use this provider for YouTube PO Tokens; when unset, POT fetching is disabled. |
-| `YT_CHANNEL` | `stable` | yt-dlp update channel: stable, nightly, master, or version |
-| `YT_DLP_UPDATE_FREQ` | `12h` | Minimum interval between yt-dlp --update-to invocations |
-| `PUID` | `1000` | Container user |
-| `PGID` | `1000` | Container group |
+| Name                     | Default                            | Description                                                                                                                                               |
+| ------------------------ | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BASE_URL`               | `http://reverseproxy.example:8024` | Public base URL for feed/media links (set this behind a reverse proxy)                                                                                    |
+| `SERVER_PORT`            | `8024`                             | Bind port for public server                                                                                                                               |
+| `ADMIN_SERVER_PORT`      | `8025`                             | Bind port for admin server (should not be exposed publicly)                                                                                               |
+| `TRUSTED_PROXIES`        | unset                              | List of local IPs or networks allowed to access the server, mainly for reverse proxy use (e.g. `["192.168.1.0/24"]`)                                      |
+| `TZ`                     | unset                              | Your timezone (set if you don't want to mount `/etc/localtime`)                                                                                           |
+| `LOG_FORMAT`             | `json`                             | `human` or `json`                                                                                                                                         |
+| `LOG_LEVEL`              | `INFO`                             | Log level                                                                                                                                                 |
+| `LOG_INCLUDE_STACKTRACE` | `false`                            | Include stack traces in error logs                                                                                                                        |
+| `POT_PROVIDER_URL`       | unset                              | Base URL for a bgutil POT provider. When set, yt-dlp will be configured to use this provider for YouTube PO Tokens; when unset, POT fetching is disabled. |
+| `YT_CHANNEL`             | `stable`                           | yt-dlp update channel: stable, nightly, master, or version                                                                                                |
+| `YT_DLP_UPDATE_FREQ`     | `12h`                              | Minimum interval between yt-dlp --update-to invocations                                                                                                   |
+| `PUID`                   | `1000`                             | Container user                                                                                                                                            |
+| `PGID`                   | `1000`                             | Container group                                                                                                                                           |
 
 
 ## HTTP endpoints
@@ -257,6 +267,14 @@ If you do want to test you have everything configured correctly (which I recomme
 
 I recommend using a filter (either `since` or `keep_last`) when setting up your feed, otherwise Anypod will download EVERY video in the playlist. On that note, `yt-dlp` only allows for day precision filtering (YYYYMMDD), tho this should be sufficient for most people.
 
+### Patreon (Beta)
+
+Patreon creator pages and individual posts are supported with the following considerations:
+
+- **Cookies required**: Patreon content typically requires authentication via cookies.txt for access to paywalled content
+- **Video-only by default**: Audio-only posts are filtered out automatically (configurable in future releases)
+- Limited testing across creator tiers; some edge cases may exist
+
 ## Development
 
 Requirements: Python 3.13+, [`uv`](https://docs.astral.sh/uv/) package manager, ffmpeg and ffprobe.
@@ -266,7 +284,7 @@ Requirements: Python 3.13+, [`uv`](https://docs.astral.sh/uv/) package manager, 
 uv sync
 
 # Run full service (dev)
-timeout 30 ./scripts/run_dev.sh [--keep]
+./scripts/run_dev.sh [--keep]
 
 # Run debug component
 ./scripts/run_debug.sh <enqueuer|downloader|ytdlp> [--keep]
@@ -276,7 +294,7 @@ uv run pre-commit run --all-files
 uv run ruff check && uv run ruff format
 uv run pyright
 uv run pytest
-uv run pytest --integration
+uv run pytest --integration # will hit actual youtube endpoints
 ```
 
 Local defaults in dev scripts:
@@ -311,7 +329,10 @@ High‑level upcoming work. See `TASK_LIST.md` for the full checklist.
 - Integrate sponsorblock to automatically cut out or add chapter markers for ads
 - Podcast feed with an endpoint you can send videos to, to dynamically create your own playlist
   - You can recreate this functionality now by creating an unlisted youtube playlist and add videos to it
-- Support for other sources (e.g. Patreon)
+- Expand Patreon support (audio-only posts, improved tier handling)
+- Support for additional sources beyond YouTube and Patreon
+- Embed episode-specific artwork directly into media files for better podcast client compatibility (especially Pocket Casts, which requires embedded artwork for per-episode images to display properly)
+  - yt-dlp supports this
 
 ## FAQ / Troubleshooting
 

--- a/TASK_LIST.md
+++ b/TASK_LIST.md
@@ -554,6 +554,8 @@ This section details the components that manage the lifecycle of downloads, from
 - [x] make override enum settings caps agnostic (e.g. requires EPISODIC or SERIAL right now)
 - [x] create an http endpoint to reset error status videos
 - [ ] create a top-level http endpoint to reset ERROR status videos across all feeds
+- [ ] convert BACK to using yt-dlp as python package
+- [ ] is it possible to introduce tier-based filtering for patreon posts?
 
 ---
 

--- a/docs/designs/05-patreon-handler.md
+++ b/docs/designs/05-patreon-handler.md
@@ -1,0 +1,190 @@
+# Patreon Handler
+
+## Overview
+
+Add first-class support for Patreon sources alongside YouTube. Users can subscribe to Patreon creator pages or individual posts and have them converted into RSS podcast feeds. This integrates with the existing handler-based yt-dlp wrapper, reusing the database, coordinator, and RSS systems without schema changes.
+
+Goals:
+- Support Patreon creator pages (playlist-like) and single posts.
+- Respect Patreon-specific requirements: cookies and referer header.
+- Default to video-focused feeds by filtering out audio-only posts (configurable later).
+- Keep changes minimal, aligned with existing handler/wrapper patterns.
+
+## Problem / Goal
+
+- Enable Patreon as a supported source in `ytdlp_wrapper` so feeds can be configured with Patreon URLs.
+- Ensure authenticated access via `cookies.txt` is respected when needed.
+- Prevent 403s by setting `--referer https://www.patreon.com`.
+- Avoid audio-only items by default using `--match-filter vcodec`.
+
+## Context / Findings
+
+Patreon behaves similarly to YouTube for yt-dlp extraction:
+- Creator pages: `extractor` = `patreon:campaign`, `_type = playlist` with many entries (URLs to posts).
+- Posts: `extractor` = `patreon`, `_type = video` (or flat `_type = url`).
+- Common fields align with YouTube (title, description, timestamp, uploader, etc.). Differences observed:
+  - Audio-only posts frequently have `ext=mp3`, `vcodec` unset/null, often missing `duration` and `thumbnail`.
+  - Video posts (e.g., via Mux) include vcodec/acodec, thumbnails, and formats.
+  - Some posts require higher tier access; yt-dlp may emit partial results with a non-zero exit code for inaccessible entries.
+    - In this case, we can add these posts to the list in case the user may get access in the future, but it should otherwise not block execution
+
+Operational caveats:
+- Cookies are typically required for paywalled content.
+- Setting the referer header helps avoid 403s.
+- `--match-filter vcodec` reliably filters out audio-only posts.
+
+## Assumptions
+
+- Cookies file is available at the configured path when needed for Patreon.
+- No DB or RSS schema changes are necessary; existing types/models suffice.
+- Existing `SourceType` enum is sufficient (SINGLE_VIDEO, PLAYLIST, CHANNEL, UNKNOWN). Patreon creator pages map best to PLAYLIST; single posts map to SINGLE_VIDEO.
+- We will add an option in the future to switch between video or audio only -- for now, we will start with defaulting to video
+
+## Constraints
+
+- Follow `SourceHandlerBase` protocol; do not refactor unrelated systems.
+- Keep YouTube behavior unchanged and backward compatible.
+- Reuse `YtdlpInfo`, `Download`, `Feed`, and the current orchestration model.
+- Minimize surface area: handler selection + small arg builder additions.
+
+## Impacted Modules
+
+- `src/anypod/ytdlp_wrapper/core/args.py`: Add `referer(url: str)` and `match_filter(expr: str)` builder methods.
+- `src/anypod/ytdlp_wrapper/patreon_handler.py` (new): Implement `SourceHandlerBase` for Patreon.
+- `src/anypod/ytdlp_wrapper/patreon_handler.py`: Add typed `PatreonEntry` helper using `YtdlpInfo`.
+- `src/anypod/ytdlp_wrapper/patreon_handler.py`: Add Patreon-specific error classes.
+- `src/anypod/ytdlp_wrapper/ytdlp_wrapper.py`: Select handler by URL host; apply referer/match-filter for Patreon.
+- `src/anypod/ytdlp_wrapper/core/core.py`: Tolerate partial success in `extract_downloads_info` when some JSON lines parsed.
+
+## Design Details
+
+### Handler Selection
+
+- Add `_select_handler(url: str) -> SourceHandlerBase` in `YtdlpWrapper`.
+  - `patreon.com` → `PatreonHandler`
+  - otherwise → `YoutubeHandler`
+- Use fresh handler selection in each high-level call (no shared mutation).
+
+### Patreon Source Type Mapping
+
+- Map `patreon:campaign` (creator pages/collections) → `SourceType.PLAYLIST`.
+- Map `patreon` (individual posts) → `SourceType.SINGLE_VIDEO`.
+
+Rationale: Creator pages behave like playlists of posts; mapping to PLAYLIST avoids YouTube-specific channel tab logic while keeping behavior consistent for filtering/thumbnail flows.
+
+### YtdlpArgs Enhancements
+
+- Implement `referer(url: str)` → append `--referer <url>`.
+- Implement `match_filter(expr: str)` → append `--match-filter <expr>`.
+
+Usage policy for Patreon:
+- Always apply `args.referer('https://www.patreon.com')` for discovery, playlist enumeration, thumbnails, and downloads.
+- Apply `args.match_filter('vcodec')` for enumeration and single-post operations by default to skip audio-only posts.
+
+### Text-only Posts Identification
+
+- Confirm how yt-dlp represents text-only Patreon posts (no media). We don't know yet how, so this requiures furthe investigation.
+- Ensure `match-filter vcodec` excludes such posts during enumeration; additionally, in single-post paths treat missing `ext` and no video evidence as filtered out.
+- If the provided example channel https://patreon.com/LemonadeStand channel lacks text-only examples, request another Patreon channel from the reviewer to validate behavior.
+
+### Error Handling
+
+- Add `YtdlpPatreonDataError` mirroring YouTube’s data errors (preserve `feed_id`/`download_id`).
+- Add `YtdlpPatreonPostFilteredOutError` for entries filtered out (e.g., no video evidence).
+- Preserve structured logging and context (feed_id, download_id).
+
+### Partial Success Tolerance (Enumeration)
+
+- Adjust `YtdlpCore.extract_downloads_info` to parse stdout lines first; if non-zero exit code but at least one valid JSON line was parsed, return parsed entries without error. Only raise when there are zero entries and a non-zero exit.
+
+### Metadata Parsing Behavior
+
+- Discovery (`determine_fetch_strategy`):
+  - Use `extract_playlist_info` with referer applied.
+  - `_type == 'playlist'` → PLAYLIST; `_type in {'url','video'}` → SINGLE_VIDEO; else fall back to resolved URL with UNKNOWN.
+
+- Feed metadata (`extract_feed_metadata`):
+  - Populate `title`, `author` (`uploader` then `channel`), `description`, feed-level `thumbnail` if present, and `last_successful_sync` from `epoch`.
+  - Respect `source_type` from discovery and include `source_url`.
+
+- Download metadata (`extract_download_metadata`):
+  - Require `id`, `title`, and published datetime (prefer `timestamp`; then `upload_date`; then `release_timestamp`).
+  - Duration: Patreon often omits it; default to `0` without raising when not live.
+  - Extension/MIME: If `ext` exists, map normally; if missing but `vcodec`/`formats` indicate video, default to `mp4`/`video/mp4`. If no video evidence (e.g., audio-only filtered), raise `YtdlpPatreonPostFilteredOutError`.
+  - `source_url`: prefer `webpage_url`, fallback to `original_url`.
+  - Thumbnails: may be absent for audio-only posts; tolerate gracefully.
+  - No live/upcoming handling for Patreon posts.
+
+### Documentation
+
+- [ ] Update README.md with end-user guidance:
+  - [ ] Note default behavior: downloads video content only (for now).
+  - [ ] Mark Patreon support as beta due to limited channel coverage.
+- [ ] Update DESIGN_DOC.md with implementation notes consistent with other sections.
+
+## Step-by-Step Implementation Plan
+
+- [x] Args builder: add `referer(url: str)` and `match_filter(expr: str)` to `YtdlpArgs`.
+- [ ] Args builder tests: covered via wrapper-level tests (no standalone file).
+
+- [x] PatreonHandler: implement `determine_fetch_strategy` (no channel-tabs logic), classify PLAYLIST vs SINGLE_VIDEO.
+- [x] PatreonEntry: implement typed helper wrapping `YtdlpInfo` with required field checks.
+- [x] PatreonHandler: implement `extract_feed_metadata`.
+- [x] PatreonHandler: implement `extract_download_metadata` with extension/mime defaults and duration=0 fallback.
+- [x] Patreon errors: implement `YtdlpPatreonDataError` and `YtdlpPatreonPostFilteredOutError`.
+
+- [ ] Wrapper: add `_select_handler(url)` and use in all flows:
+  - [ ] `discover_feed_properties`
+  - [ ] `fetch_playlist_metadata`
+  - [ ] `download_feed_thumbnail`
+  - [ ] `fetch_new_downloads_metadata`
+  - [ ] `download_media_to_file`
+- [ ] Wrapper (Patreon): apply `referer('https://www.patreon.com')` universally.
+- [ ] Wrapper (Patreon): apply `match_filter('vcodec')` in enumeration and single-post paths.
+- [ ] Ensure YouTube behavior unchanged.
+
+- [ ] Partial success tolerance: experiment with yt-dlp outputs to confirm stderr/exit-code patterns.
+- [ ] Partial success tolerance: update `YtdlpCore.extract_downloads_info` to return parsed entries on non-zero exit if at least one JSON line valid; else raise.
+
+- [ ] Text-only posts: confirm yt-dlp behavior for text-only entries (no media/formats).
+- [ ] Text-only posts: ensure enumeration excludes them (via match-filter) and single-post parse treats them as filtered.
+- [ ] Text-only posts: if no text-only example found on target channel, request alternative channel to test.
+
+- [ ] Tests: Patreon handler discovery classification (single/playlist/unknown) with mocked `extract_playlist_info`.
+- [ ] Tests: Patreon entry parsing (success, missing publish dt → error, missing ext + no video evidence → filtered, defaults when formats indicate video, text-only → filtered).
+- [ ] Tests: Wrapper dispatch (URL → handler) and arg augmentation (referer/match-filter present for Patreon; YouTube unaffected).
+- [ ] Tests: Core partial success tolerance in `extract_downloads_info`.
+
+## Test Plan
+
+- [ ] Unit: `test_patreon_determine_fetch_strategy_*` (single, playlist, unknown).
+- [ ] Unit: `test_patreon_extract_download_metadata_*` (success, missing publish dt → error, audio-only → filtered, text-only → filtered).
+- [ ] Unit: `test_wrapper_selects_patreon_handler_and_sets_referer_and_match_filter`.
+- [ ] Unit: `test_extract_downloads_info_tolerates_partial_success`.
+- [ ] Unit: Ensure existing YouTube tests continue to pass.
+
+- [ ] Integration (manual/optional): With valid Patreon cookies, run targeted extraction against public/free posts to validate end-to-end behavior. Keep out of CI by default.
+- [ ] Integration (manual/optional): Validate text-only post handling; if no example available, request alternate channel/sample.
+
+## Backward Compatibility
+
+- No config changes required. Existing YouTube feeds unaffected.
+- Patreon without cookies may yield empty results or errors surfaced as `YtdlpApiError`.
+  - [ ] Make sure there is an integration test that confirms behavior with no cookie
+- No DB or RSS schema modifications.
+
+## Open Questions / Future Work
+
+- [ ] Audio-only Patreon posts: add opt-in config to include audio-only (skip `match-filter vcodec`).
+- Tier-based filtering / error surfaces for inaccessible posts.
+  - [ ] Is there any metadata that would inform whether the inaccessible post has video content, or is that blocked entirely
+  - [ ] Behavior should be to simply queue the inaccessible post for download, but otherwise continue execution (unless we can ascertain that it DOESN'T have a video, in which case we skip)
+- [ ] Centralize shared entry parsing across handlers to reduce duplication as more sources are added.
+- [ ] Consider feed-level thumbnail behavior for Patreon if playlist thumbnails are inconsistently available.
+
+## Review Gate (PRD)
+
+Stop here for review/approval. After approval:
+- [ ] Implement scoped changes and add unit tests per plan.
+- [ ] Run `uv run pytest` and `uv run pre-commit run --all-files` to validate.
+- [ ] Provide a brief summary with file references on handoff.

--- a/docs/designs/05-patreon-handler.md
+++ b/docs/designs/05-patreon-handler.md
@@ -133,15 +133,15 @@ Usage policy for Patreon:
 - [x] PatreonHandler: implement `extract_download_metadata` with extension/mime defaults and duration=0 fallback.
 - [x] Patreon errors: implement `YtdlpPatreonDataError` and `YtdlpPatreonPostFilteredOutError`.
 
-- [ ] Wrapper: add `_select_handler(url)` and use in all flows:
+- [x] Wrapper: add host-based handler selector and use in all flows:
   - [ ] `discover_feed_properties`
   - [ ] `fetch_playlist_metadata`
   - [ ] `download_feed_thumbnail`
   - [ ] `fetch_new_downloads_metadata`
   - [ ] `download_media_to_file`
-- [ ] Wrapper (Patreon): apply `referer('https://www.patreon.com')` universally.
-- [ ] Wrapper (Patreon): apply `match_filter('vcodec')` in enumeration and single-post paths.
-- [ ] Ensure YouTube behavior unchanged.
+- [x] Wrapper (Patreon): apply `referer('https://www.patreon.com')` universally.
+- [x] Wrapper (Patreon): apply `match_filter('vcodec')` in enumeration and single-post paths.
+- [x] Ensure YouTube behavior unchanged.
 
 - [ ] Partial success tolerance: experiment with yt-dlp outputs to confirm stderr/exit-code patterns.
 - [ ] Partial success tolerance: update `YtdlpCore.extract_downloads_info` to return parsed entries on non-zero exit if at least one JSON line valid; else raise.
@@ -150,8 +150,8 @@ Usage policy for Patreon:
 - [ ] Text-only posts: ensure enumeration excludes them (via match-filter) and single-post parse treats them as filtered.
 - [ ] Text-only posts: if no text-only example found on target channel, request alternative channel to test.
 
-- [ ] Tests: Patreon handler discovery classification (single/playlist/unknown) with mocked `extract_playlist_info`.
-- [ ] Tests: Patreon entry parsing (success, missing publish dt → error, missing ext + no video evidence → filtered, defaults when formats indicate video, text-only → filtered).
+- [x] Tests: Patreon handler discovery classification (single/playlist/unknown) with mocked `extract_playlist_info`.
+- [x] Tests: Patreon entry parsing (success, missing publish dt → error, missing ext → filtered, probe duration path).
 - [ ] Tests: Wrapper dispatch (URL → handler) and arg augmentation (referer/match-filter present for Patreon; YouTube unaffected).
 - [ ] Tests: Core partial success tolerance in `extract_downloads_info`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
     "pytest-xdist>=3.7.0",
     "respx>=0.22.0",
     "ruff>=0.11.7",
-    "yt-dlp>=2025.8.22",
+    "yt-dlp[default]>=2025.8.22",
 ]
 
 [project.scripts]

--- a/src/anypod/cli/debug_downloader.py
+++ b/src/anypod/cli/debug_downloader.py
@@ -15,9 +15,11 @@ from ..db import AppStateDatabase, DownloadDatabase
 from ..db.sqlalchemy_core import SqlalchemyCore
 from ..db.types import Download, DownloadStatus
 from ..exceptions import DatabaseOperationError, DownloadError
+from ..ffprobe import FFProbe
 from ..file_manager import FileManager
 from ..path_manager import PathManager
 from ..ytdlp_wrapper import YtdlpWrapper
+from ..ytdlp_wrapper.base_handler import HandlerSelector
 
 logger = logging.getLogger(__name__)
 
@@ -53,12 +55,15 @@ async def run_debug_downloader_mode(
         file_manager = FileManager(paths)
 
         app_state_db = AppStateDatabase(db_core)
+        ffprobe = FFProbe()
+        handler_selector = HandlerSelector(ffprobe)
         ytdlp_wrapper = YtdlpWrapper(
             paths,
             pot_provider_url=settings.pot_provider_url,
             app_state_db=app_state_db,
             yt_channel=settings.yt_channel,
             yt_update_freq=settings.yt_dlp_update_freq,
+            handler_selector=handler_selector,
         )
         downloader = Downloader(download_db, file_manager, ytdlp_wrapper)
     except Exception as e:

--- a/src/anypod/cli/debug_enqueuer.py
+++ b/src/anypod/cli/debug_enqueuer.py
@@ -14,6 +14,8 @@ from ..db import AppStateDatabase, DownloadDatabase, FeedDatabase
 from ..db.sqlalchemy_core import SqlalchemyCore
 from ..db.types import Download, DownloadStatus
 from ..exceptions import DatabaseOperationError, EnqueueError, StateReconciliationError
+from ..ffmpeg import FFmpeg
+from ..ffprobe import FFProbe
 from ..file_manager import FileManager
 from ..image_downloader import ImageDownloader
 from ..path_manager import PathManager
@@ -60,7 +62,9 @@ async def run_debug_enqueuer_mode(
             yt_update_freq=settings.yt_dlp_update_freq,
         )
         pruner = Pruner(feed_db, download_db, file_manager)
-        image_downloader = ImageDownloader(paths, ytdlp_wrapper)
+        ffprobe = FFProbe()
+        ffmpeg = FFmpeg()
+        image_downloader = ImageDownloader(paths, ytdlp_wrapper, ffprobe, ffmpeg)
         state_reconciler = StateReconciler(
             file_manager,
             image_downloader,

--- a/src/anypod/cli/debug_enqueuer.py
+++ b/src/anypod/cli/debug_enqueuer.py
@@ -21,6 +21,7 @@ from ..image_downloader import ImageDownloader
 from ..path_manager import PathManager
 from ..state_reconciler import StateReconciler
 from ..ytdlp_wrapper import YtdlpWrapper
+from ..ytdlp_wrapper.base_handler import HandlerSelector
 
 logger = logging.getLogger(__name__)
 
@@ -54,15 +55,17 @@ async def run_debug_enqueuer_mode(
         download_db = DownloadDatabase(db_core)
         file_manager = FileManager(paths)
         app_state_db = AppStateDatabase(db_core)
+        ffprobe = FFProbe()
+        handler_selector = HandlerSelector(ffprobe)
         ytdlp_wrapper = YtdlpWrapper(
             paths,
             pot_provider_url=settings.pot_provider_url,
             app_state_db=app_state_db,
             yt_channel=settings.yt_channel,
             yt_update_freq=settings.yt_dlp_update_freq,
+            handler_selector=handler_selector,
         )
         pruner = Pruner(feed_db, download_db, file_manager)
-        ffprobe = FFProbe()
         ffmpeg = FFmpeg()
         image_downloader = ImageDownloader(paths, ytdlp_wrapper, ffprobe, ffmpeg)
         state_reconciler = StateReconciler(

--- a/src/anypod/cli/debug_ytdlp.py
+++ b/src/anypod/cli/debug_ytdlp.py
@@ -10,8 +10,10 @@ from ..db import AppStateDatabase
 from ..db.sqlalchemy_core import SqlalchemyCore
 from ..db.types import DownloadStatus
 from ..exceptions import YtdlpApiError
+from ..ffprobe import FFProbe
 from ..path_manager import PathManager
 from ..ytdlp_wrapper import YtdlpWrapper
+from ..ytdlp_wrapper.base_handler import HandlerSelector
 
 logger = logging.getLogger(__name__)
 
@@ -35,12 +37,14 @@ async def run_debug_ytdlp_mode(settings: AppSettings, paths: PathManager) -> Non
 
     db_core = SqlalchemyCore(await paths.db_dir())
     app_state_db = AppStateDatabase(db_core)
+    handler_selector = HandlerSelector(FFProbe())
     ytdlp_wrapper = YtdlpWrapper(
         paths,
         pot_provider_url=settings.pot_provider_url,
         app_state_db=app_state_db,
         yt_channel=settings.yt_channel,
         yt_update_freq=settings.yt_dlp_update_freq,
+        handler_selector=handler_selector,
     )
 
     for feed_id, feed_config in settings.feeds.items():

--- a/src/anypod/cli/default.py
+++ b/src/anypod/cli/default.py
@@ -15,6 +15,8 @@ from ..exceptions import (
     DatabaseOperationError,
     StateReconciliationError,
 )
+from ..ffmpeg import FFmpeg
+from ..ffprobe import FFProbe
 from ..file_manager import FileManager
 from ..image_downloader import ImageDownloader
 from ..path_manager import PathManager
@@ -105,7 +107,14 @@ async def _init(
         yt_update_freq=settings.yt_dlp_update_freq,
     )
     rss_generator = RSSFeedGenerator(download_db=download_db, paths=path_manager)
-    image_downloader = ImageDownloader(paths=path_manager, ytdlp_wrapper=ytdlp_wrapper)
+    ffprobe = FFProbe()
+    ffmpeg = FFmpeg()
+    image_downloader = ImageDownloader(
+        paths=path_manager,
+        ytdlp_wrapper=ytdlp_wrapper,
+        ffprobe=ffprobe,
+        ffmpeg=ffmpeg,
+    )
 
     # Initialize data coordinator components
     enqueuer = Enqueuer(

--- a/src/anypod/cli/default.py
+++ b/src/anypod/cli/default.py
@@ -25,6 +25,7 @@ from ..schedule import FeedScheduler
 from ..server import create_admin_server, create_server
 from ..state_reconciler import StateReconciler
 from ..ytdlp_wrapper import YtdlpWrapper
+from ..ytdlp_wrapper.base_handler import HandlerSelector
 
 logger = logging.getLogger(__name__)
 
@@ -99,15 +100,17 @@ async def _init(
     download_db = DownloadDatabase(db_core)
 
     # Initialize application components
+    ffprobe = FFProbe()
+    handler_selector = HandlerSelector(ffprobe)
     ytdlp_wrapper = YtdlpWrapper(
         paths=path_manager,
         pot_provider_url=settings.pot_provider_url,
         app_state_db=app_state_db,
         yt_channel=settings.yt_channel,
         yt_update_freq=settings.yt_dlp_update_freq,
+        handler_selector=handler_selector,
     )
     rss_generator = RSSFeedGenerator(download_db=download_db, paths=path_manager)
-    ffprobe = FFProbe()
     ffmpeg = FFmpeg()
     image_downloader = ImageDownloader(
         paths=path_manager,

--- a/src/anypod/config/config.py
+++ b/src/anypod/config/config.py
@@ -290,7 +290,6 @@ class AppSettings(BaseSettings):
         env_prefix="",
         env_nested_delimiter="__",
         # yaml_file=None, # Removed as we handle YAML via YamlFileFromFieldSource
-        # yaml_file_encoding="utf-8",
         cli_parse_args=True,
         cli_ignore_unknown_args=True,
         cli_kebab_case=True,

--- a/src/anypod/exceptions.py
+++ b/src/anypod/exceptions.py
@@ -337,3 +337,28 @@ class SchedulerError(AnypodError):
     ):
         super().__init__(message)
         self.feed_id = feed_id
+
+
+class FFProbeError(AnypodError):
+    """Raised when ffprobe execution fails.
+
+    Attributes:
+        stderr: Raw stderr output from the ffprobe subprocess.
+        args: Arguments used to invoke ffprobe (excluding the executable name).
+    """
+
+    def __init__(self, message: str, stderr: str | None = None):
+        super().__init__(message)
+        self.stderr = stderr
+
+
+class FFmpegError(AnypodError):
+    """Raised when ffmpeg execution fails.
+
+    Attributes:
+        stderr: Raw stderr output from the ffmpeg subprocess.
+    """
+
+    def __init__(self, message: str, stderr: str | None = None):
+        super().__init__(message)
+        self.stderr = stderr

--- a/src/anypod/exceptions.py
+++ b/src/anypod/exceptions.py
@@ -206,6 +206,26 @@ class YtdlpDataError(YtdlpError):
     """Raised when yt-dlp data extraction fails."""
 
 
+class YtdlpDownloadFilteredOutError(YtdlpDataError):
+    """Raised when yt-dlp filters out an item during processing.
+
+    Attributes:
+        feed_id: The associated feed identifier, when available.
+        download_id: The filtered download identifier, when available.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        feed_id: str | None = None,
+        download_id: str | None = None,
+    ):
+        super().__init__(message)
+        self.feed_id = feed_id
+        self.download_id = download_id
+
+
 class YtdlpFieldMissingError(YtdlpDataError):
     """Raised when a required field is missing from yt-dlp data.
 

--- a/src/anypod/ffmpeg.py
+++ b/src/anypod/ffmpeg.py
@@ -1,0 +1,58 @@
+"""Thin async wrapper around ffmpeg for simple media conversions.
+
+Currently used to convert arbitrary images to JPG using MJPEG encoder.
+"""
+
+import asyncio
+from pathlib import Path
+
+from .exceptions import FFmpegError
+
+
+class FFmpeg:
+    """Run ffmpeg commands for media processing.
+
+    Provides minimal helpers for specific conversions needed by the codebase.
+    """
+
+    async def _run(self, *args: str) -> tuple[int, bytes, bytes]:
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "ffmpeg",
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError as e:
+            raise FFmpegError("ffmpeg executable not found") from e
+        except OSError as e:
+            raise FFmpegError("Failed to execute ffmpeg") from e
+
+        try:
+            stdout, stderr = await process.communicate()
+        except asyncio.CancelledError:
+            # Ensure subprocess cleanup on cancellation
+            process.kill()
+            raise
+
+        return process.returncode or 0, stdout or b"", stderr or b""
+
+    async def convert_image_to_jpg(self, input_path: Path, output_path: Path) -> None:
+        """Convert an image file to a JPG using ffmpeg (MJPEG).
+
+        Raises:
+            FFmpegError: When conversion fails.
+        """
+        rc, _, stderr = await self._run(
+            "-i",
+            str(input_path),
+            "-f",
+            "mjpeg",
+            "-y",
+            str(output_path),
+        )
+        if rc != 0:
+            raise FFmpegError(
+                "Image conversion to JPG failed",
+                stderr=stderr.decode() if stderr else None,
+            )

--- a/src/anypod/ffprobe.py
+++ b/src/anypod/ffprobe.py
@@ -1,0 +1,160 @@
+"""Thin async wrapper around ffprobe for media probing.
+
+Provides centralized helpers for:
+- Determining if an image file is JPG (MJPEG) using local file paths
+- Extracting media duration (in seconds) from local files or remote URLs
+
+All methods are implemented using asyncio subprocess execution to avoid
+blocking the event loop.
+"""
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+from .exceptions import FFProbeError
+
+
+class FFProbe:
+    """Run ffprobe commands to gather media metadata.
+
+    This class provides minimal, focused helpers that wrap common ffprobe
+    invocations used throughout the codebase. It does not attempt to be an
+    exhaustive interface to ffprobe.
+    """
+
+    async def _run(self, *args: str) -> tuple[int, bytes, bytes]:
+        """Execute ffprobe with the given arguments.
+
+        Args:
+            *args: Arguments passed directly to the ffprobe executable.
+
+        Returns:
+            Tuple of (returncode, stdout, stderr).
+
+        Raises:
+            FileNotFoundError: When ffprobe is not installed/available in PATH.
+            OSError: When the subprocess fails to execute.
+        """
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "ffprobe",
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError as e:
+            raise FFProbeError("ffprobe executable not found") from e
+        except OSError as e:
+            raise FFProbeError("Failed to execute ffprobe") from e
+
+        try:
+            stdout, stderr = await process.communicate()
+        except asyncio.CancelledError:
+            # Ensure subprocess cleanup on cancellation
+            process.kill()
+            raise
+
+        return process.returncode or 0, stdout or b"", stderr or b""
+
+    async def is_jpg_file(self, file_path: Path) -> bool:
+        """Return True if the file's first stream is MJPEG (JPG).
+
+        Args:
+            file_path: Local filesystem path to an image file.
+
+        Returns:
+            True if the first stream codec is ``mjpeg``; False otherwise.
+
+        Raises:
+            FileNotFoundError: If ffprobe is not installed.
+            OSError: If the subprocess fails to execute.
+            RuntimeError: If ffprobe returns a non-zero status or JSON cannot be parsed.
+        """
+        rc, stdout, stderr = await self._run(
+            "-v",
+            "quiet",
+            "-print_format",
+            "json",
+            "-show_streams",
+            str(file_path),
+        )
+        if rc != 0:
+            raise FFProbeError(
+                "ffprobe failed (is_jpg_file)",
+                stderr=stderr.decode() if stderr else None,
+            )
+        try:
+            data: dict[str, Any] = json.loads(stdout.decode())
+        except json.JSONDecodeError as e:
+            raise FFProbeError(
+                "Failed to parse ffprobe JSON output (is_jpg_file)",
+                stderr=stdout.decode(),
+            ) from e
+
+        try:
+            streams = data.get("streams", [])
+            if streams:
+                codec_name = streams[0].get("codec_name", "").lower()
+                return codec_name == "mjpeg"
+        except Exception as e:
+            raise FFProbeError(
+                "Unexpected ffprobe output", stderr=stdout.decode()
+            ) from e
+        return False
+
+    async def _duration_seconds(
+        self, probe_target: str, headers: dict[str, str] | None
+    ) -> int:
+        """Core helper to extract duration seconds; raises on failure.
+
+        Args:
+            probe_target: Local file path or remote URL string.
+            headers: Optional HTTP headers (only used for remote URLs).
+
+        Returns:
+            Integer duration in seconds.
+
+        Raises:
+            FFProbeError: When ffprobe fails or output is unparsable/empty.
+        """
+        args: list[str] = [
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+        ]
+        if headers:
+            for k, v in headers.items():
+                args.extend(["-headers", f"{k}: {v}"])
+        args.append(probe_target)
+
+        rc, stdout, stderr = await self._run(*args)
+        if rc != 0:
+            raise FFProbeError(
+                "ffprobe failed (duration)",
+                stderr=stderr.decode() if stderr else None,
+            )
+        text = stdout.decode().strip()
+        if not text:
+            raise FFProbeError(
+                "ffprobe returned empty duration output",
+                stderr=stderr.decode() if stderr else None,
+            )
+        try:
+            return int(float(text))
+        except ValueError as e:
+            raise FFProbeError("Failed to parse duration output", stderr=text) from e
+
+    async def get_duration_seconds_from_file(self, file_path: Path) -> int:
+        """Return media duration in seconds from a local file; raises on failure."""
+        return await self._duration_seconds(str(file_path), headers=None)
+
+    async def get_duration_seconds_from_url(
+        self, url: str, headers: dict[str, str] | None = None
+    ) -> int:
+        """Return media duration in seconds by probing a remote URL; raises on failure."""
+        return await self._duration_seconds(url, headers=headers)

--- a/src/anypod/ytdlp_wrapper/core/args.py
+++ b/src/anypod/ytdlp_wrapper/core/args.py
@@ -78,6 +78,10 @@ class YtdlpArgs:
         # Extractor args
         self._extractor_args: list[str] = []
 
+        # Networking / filtering
+        self._referer: str | None = None
+        self._match_filter: str | None = None
+
     def quiet(self) -> "YtdlpArgs":
         """Enable quiet mode (suppress verbose output)."""
         self._quiet = True
@@ -219,6 +223,30 @@ class YtdlpArgs:
         self._break_match_filters = filter_expr
         return self
 
+    def referer(self, url: str) -> "YtdlpArgs":
+        """Set the HTTP Referer header for requests.
+
+        Args:
+            url: The referer URL to pass to yt-dlp (e.g., "https://www.patreon.com").
+
+        Returns:
+            The builder instance for chaining.
+        """
+        self._referer = url
+        return self
+
+    def match_filter(self, filter_expr: str) -> "YtdlpArgs":
+        """Include only entries matching the filter expression.
+
+        Args:
+            filter_expr: A yt-dlp match filter expression (e.g., "vcodec").
+
+        Returns:
+            The builder instance for chaining.
+        """
+        self._match_filter = filter_expr
+        return self
+
     def update_to(self, channel: str) -> "YtdlpArgs":
         """Update to a specific channel or version.
 
@@ -332,6 +360,12 @@ class YtdlpArgs:
         # Extractor args
         for ex_arg in self._extractor_args:
             cmd.extend(["--extractor-args", ex_arg])
+
+        # Networking / filtering
+        if self._referer is not None:
+            cmd.extend(["--referer", self._referer])
+        if self._match_filter is not None:
+            cmd.extend(["--match-filter", self._match_filter])
 
         # Update control - skip in pytest to avoid issues with pip-installed yt-dlp
         if self._update_to is not None and not self._running_under_pytest():

--- a/src/anypod/ytdlp_wrapper/patreon_handler.py
+++ b/src/anypod/ytdlp_wrapper/patreon_handler.py
@@ -1,0 +1,626 @@
+"""Patreon-specific handler for yt-dlp operations.
+
+This module provides Patreon-specific implementations for fetch strategy
+determination and metadata parsing. Patreon behaves similarly to YouTube in
+yt-dlp's extraction model: creator pages act like playlists and individual
+posts act like single videos.
+"""
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+import logging
+from typing import Any, cast
+
+from ..db.types import Download, DownloadStatus, Feed, SourceType
+from ..exceptions import (
+    FFProbeError,
+    YtdlpDataError,
+    YtdlpDownloadFilteredOutError,
+    YtdlpFieldInvalidError,
+    YtdlpFieldMissingError,
+)
+from ..ffprobe import FFProbe
+from ..mimetypes import mimetypes
+from .core import YtdlpArgs, YtdlpCore, YtdlpInfo
+
+logger = logging.getLogger(__name__)
+
+_PATREON_REFERER = "https://www.patreon.com"
+
+
+class YtdlpPatreonDataError(YtdlpDataError):
+    """Raised when yt-dlp data extraction fails for Patreon.
+
+    Attributes:
+        feed_id: The feed identifier associated with the error.
+        download_id: The download identifier associated with the error.
+    """
+
+    def __init__(
+        self, message: str, feed_id: str | None = None, download_id: str | None = None
+    ):
+        super().__init__(f"Patreon Parser: {message}")
+        self.feed_id = feed_id
+        self.download_id = download_id
+
+
+class YtdlpPatreonPostFilteredOutError(YtdlpDownloadFilteredOutError):
+    """Raised when a post is filtered out (e.g., audio-only or text-only).
+
+    Attributes:
+        feed_id: The feed identifier associated with the error.
+        download_id: The download identifier associated with the error.
+    """
+
+    def __init__(self, feed_id: str | None = None, download_id: str | None = None):
+        super().__init__(
+            "Patreon: Post filtered out by yt-dlp.",
+            feed_id=feed_id,
+            download_id=download_id,
+        )
+
+
+class PatreonEntry:
+    """Represent a single Patreon entry with field extraction.
+
+    Provides typed access to Patreon-specific fields from yt-dlp metadata,
+    with error handling and data validation for common post properties.
+
+    Attributes:
+        feed_id: The feed identifier this entry belongs to.
+        download_id: The Patreon post ID.
+        _ytdlp_info: The underlying yt-dlp metadata.
+    """
+
+    def __init__(self, ytdlp_info: YtdlpInfo, feed_id: str):
+        self._ytdlp_info = ytdlp_info
+        self.feed_id = feed_id
+
+        try:
+            self.download_id = self._ytdlp_info.required("id", str)
+        except (YtdlpFieldMissingError, YtdlpFieldInvalidError) as e:
+            raise YtdlpPatreonDataError(
+                message="Failed to parse Patreon entry.",
+                feed_id=self.feed_id,
+                download_id="<missing_id>",
+            ) from e
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, PatreonEntry):
+            return NotImplemented
+        return self.feed_id == other.feed_id and self._ytdlp_info == other._ytdlp_info
+
+    @contextmanager
+    def _annotate_exceptions(self) -> Generator[None]:
+        try:
+            yield
+        except (YtdlpFieldMissingError, YtdlpFieldInvalidError) as e:
+            raise YtdlpPatreonDataError(
+                message="Failed to parse Patreon entry.",
+                feed_id=self.feed_id,
+                download_id=self.download_id,
+            ) from e
+
+    # --- common fields ---
+
+    @property
+    def webpage_url(self) -> str | None:
+        """Get the webpage URL for the post."""
+        with self._annotate_exceptions():
+            return self._ytdlp_info.get("webpage_url", str)
+
+    @property
+    def original_url(self) -> str | None:
+        """Get the original URL for the post."""
+        with self._annotate_exceptions():
+            return self._ytdlp_info.get("original_url", str)
+
+    @property
+    def extractor(self) -> str | None:
+        """Get the extractor name (normalized to lowercase)."""
+        with self._annotate_exceptions():
+            extractor = self._ytdlp_info.get("extractor", str)
+            return extractor.lower() if extractor else None
+
+    @property
+    def type(self) -> str | None:
+        """Get the entry type from yt-dlp metadata."""
+        with self._annotate_exceptions():
+            return self._ytdlp_info.get("_type", str)
+
+    @property
+    def epoch(self) -> datetime:
+        """Get the timestamp of the request."""
+        with self._annotate_exceptions():
+            epoch_timestamp = self._ytdlp_info.required("epoch", int)
+            return datetime.fromtimestamp(epoch_timestamp, tz=UTC)
+
+    # --- feed-level metadata fields ---
+
+    @property
+    def title(self) -> str:
+        """Get the post title."""
+        with self._annotate_exceptions():
+            return self._ytdlp_info.required("title", str)
+
+    @property
+    def description(self) -> str | None:
+        """Get the description for the post or playlist."""
+        with self._annotate_exceptions():
+            return self._ytdlp_info.get("description", str)
+
+    @property
+    def uploader(self) -> str | None:
+        """Get the campaign/channel name (primary) with individual uploader as fallback."""
+        with self._annotate_exceptions():
+            return self._ytdlp_info.get("channel", str) or self._ytdlp_info.get(
+                "uploader", str
+            )
+
+    @property
+    def thumbnail(self) -> str | None:
+        """Get a best-effort JPG/PNG thumbnail URL for the post."""
+        with self._annotate_exceptions():
+            thumbnails = self._ytdlp_info.thumbnails()
+            if not thumbnails:
+                return self._ytdlp_info.get("thumbnail", str)
+            best = thumbnails.best_supported()
+            if not best:
+                logger.warning(
+                    "No JPG/PNG thumbnails available for Patreon entry.",
+                    extra={
+                        "source_url": self.webpage_url,
+                        "download_id": self.download_id,
+                    },
+                )
+                return None
+            return best.url
+
+    # --- individual post fields ---
+
+    @property
+    def media_url(self) -> str | None:
+        """Return top-level media URL if present (e.g., direct MP3 URL)."""
+        with self._annotate_exceptions():
+            return self._ytdlp_info.get("url", str)
+
+    @property
+    def requested_download_urls(self) -> list[str]:
+        """Return ordered candidate URLs extracted from requested_downloads.
+
+        For each entry, prefer `url` then `manifest_url`.
+        """
+        urls: list[str] = []
+        with self._annotate_exceptions():
+            rd_list = self._ytdlp_info.get("requested_downloads", list[Any])
+        if not rd_list:
+            return urls
+        for rd in rd_list:
+            if not isinstance(rd, dict):
+                continue
+            rd_dict: dict[str, Any] = cast(dict[str, Any], rd)
+            url = rd_dict.get("url")
+            if isinstance(url, str):
+                urls.append(url)
+                continue
+            manifest_url = rd_dict.get("manifest_url")
+            if isinstance(manifest_url, str):
+                urls.append(manifest_url)
+        return urls
+
+    @property
+    def first_format_url(self) -> str | None:
+        """Return first format's URL (or manifest URL) if available.
+
+        For Patreon/Mux, all formats should have same content length.
+        """
+        with self._annotate_exceptions():
+            fmts = self._ytdlp_info.get("formats", list[Any])
+        if not fmts:
+            return None
+        first = fmts[0]
+        if not isinstance(first, dict):
+            return None
+        first_dict: dict[str, Any] = cast(dict[str, Any], first)
+        url = first_dict.get("url")
+        if isinstance(url, str):
+            return url
+        manifest_url = first_dict.get("manifest_url")
+        if isinstance(manifest_url, str):
+            return manifest_url
+        return None
+
+    @property
+    def ext(self) -> str | None:
+        """Get the file extension for the post's media (if any)."""
+        with self._annotate_exceptions():
+            return self._ytdlp_info.get("ext", str)
+
+    @property
+    def mime_type_from_ext(self) -> str:
+        """Map extension to MIME type, defaulting to octet-stream when unknown."""
+        ext = self.ext
+        if ext is None:
+            return "application/octet-stream"
+        if not ext.startswith("."):
+            ext = f".{ext}"
+
+        mime_type = mimetypes.guess_type(f"file{ext}")[0]
+        if mime_type is None:
+            raise YtdlpPatreonDataError(
+                f"Could not determine MIME type for extension '{ext}'.",
+                feed_id=self.feed_id,
+                download_id=self.download_id,
+            )
+        return mime_type
+
+    @property
+    def filesize(self) -> int:
+        """Get the file size using filesize_approx as fallback; default 0."""
+        with self._annotate_exceptions():
+            return (
+                self._ytdlp_info.get("filesize", int)
+                or self._ytdlp_info.get("filesize_approx", int)
+                or 0
+            )
+
+    @property
+    def timestamp(self) -> datetime | None:
+        """Get the timestamp as a UTC datetime object."""
+        with self._annotate_exceptions():
+            ts = self._ytdlp_info.get("timestamp", (int, float))
+        if ts is None:
+            return None
+        try:
+            return datetime.fromtimestamp(float(ts), UTC)
+        except (TypeError, ValueError, OSError) as e:
+            raise YtdlpPatreonDataError(
+                message=f"Invalid timestamp: '{ts}'.",
+                feed_id=self.feed_id,
+                download_id=self.download_id,
+            ) from e
+
+    @property
+    def published_source_field(self) -> str:
+        """Source field used for determining the published datetime."""
+        if self.timestamp:
+            return "timestamp"
+        else:
+            return "unknown"
+
+    @property
+    def duration_or_default(self) -> int:
+        """Get duration in seconds; default to 0 when missing or invalid.
+
+        Patreon posts frequently omit duration for audio-only or even video posts.
+        This accessor deliberately avoids raising for missing duration.
+        """
+        match self._ytdlp_info.get_raw("duration"):
+            case None:
+                return 0
+            case bool():
+                # Avoid bool subclass of int confusion
+                return 0
+            case float() as num:
+                return int(num)
+            case int() as num:
+                return num
+            case str() as s:
+                try:
+                    return int(float(s))
+                except ValueError:
+                    return 0
+            case _:
+                return 0
+
+    @property
+    def quality_info(self) -> str | None:
+        """Get a concise quality string when available.
+
+        Keep this minimal to avoid large parsing overhead. Attempts resolution
+        or height, then simple codec hints.
+        """
+        with self._annotate_exceptions():
+            parts: list[str] = []
+            if resolution := self._ytdlp_info.get("resolution", str):
+                parts.append(resolution)
+            elif height := self._ytdlp_info.get("height", int):
+                parts.append(f"{height}p")
+
+            acodec = self._ytdlp_info.get("acodec", str)
+            if acodec and acodec != "none":
+                parts.append(acodec)
+
+            return " | ".join(parts) if parts else None
+
+
+class PatreonHandler:
+    """Patreon-specific implementation for fetching strategy and parsing.
+
+    Implements the SourceHandlerBase protocol to provide Patreon-specific
+    behavior for URL classification and metadata parsing into Download
+    objects. No live/upcoming logic is applied for Patreon posts.
+    """
+
+    def __init__(self, ffprobe: FFProbe):
+        self._ffprobe = ffprobe
+
+    async def determine_fetch_strategy(
+        self,
+        feed_id: str,
+        initial_url: str,
+        base_args: YtdlpArgs,
+    ) -> tuple[str | None, SourceType]:
+        """Determine the fetch strategy for a Patreon URL.
+
+        Args:
+            feed_id: The feed identifier.
+            initial_url: The initial URL to analyze.
+            base_args: Pre-configured YtdlpArgs with shared settings.
+
+        Returns:
+            Tuple of (final_url_to_fetch, source_type).
+        """
+        logger.debug(
+            "Determining Patreon fetch strategy.", extra={"initial_url": initial_url}
+        )
+
+        discovery_args = (
+            base_args.skip_download().flat_playlist().referer("https://www.patreon.com")
+        )
+
+        discovery_info = await YtdlpCore.extract_playlist_info(
+            discovery_args, initial_url
+        )
+        if not discovery_info:
+            logger.warning(
+                "Patreon discovery returned no info; defaulting to UNKNOWN.",
+                extra={"initial_url": initial_url},
+            )
+            return initial_url, SourceType.UNKNOWN
+
+        entry = PatreonEntry(discovery_info, feed_id)
+        fetch_url = entry.webpage_url or initial_url
+
+        logger.debug(
+            "Patreon discovery call successful.",
+            extra={
+                "initial_url": initial_url,
+                "fetch_url": fetch_url,
+                "extractor": entry.extractor,
+                "resolved_type": entry.type or "<unknown>",
+            },
+        )
+
+        # Classify by extractor/type
+        if entry.type == "playlist" or entry.extractor == "patreon:campaign":
+            return fetch_url, SourceType.PLAYLIST
+        elif entry.type in ("video", "url") or entry.extractor == "patreon":
+            return fetch_url, SourceType.SINGLE_VIDEO
+
+        logger.warning(
+            "Unhandled Patreon URL classification. Defaulting to UNKNOWN.",
+            extra={
+                "initial_url": initial_url,
+                "fetch_url": fetch_url,
+                "extractor": entry.extractor,
+                "type": entry.type,
+            },
+        )
+        return fetch_url, SourceType.UNKNOWN
+
+    def prepare_playlist_info_args(
+        self,
+        args: YtdlpArgs,
+    ) -> YtdlpArgs:
+        """Apply Patreon referer for playlist metadata calls."""
+        return args.referer(_PATREON_REFERER)
+
+    def extract_feed_metadata(
+        self,
+        feed_id: str,
+        ytdlp_info: YtdlpInfo,
+        source_type: SourceType,
+        source_url: str,
+    ) -> Feed:
+        """Extract feed-level metadata from Patreon yt-dlp response.
+
+        Args:
+            feed_id: The feed identifier.
+            ytdlp_info: The yt-dlp metadata information.
+            source_type: The type of source being parsed.
+            source_url: The original source URL for this feed.
+
+        Returns:
+            Feed object with extracted metadata populated.
+        """
+        logger.debug(
+            "Extracting Patreon feed metadata.",
+            extra={"feed_id": feed_id, "source_type": source_type},
+        )
+
+        p = PatreonEntry(ytdlp_info, feed_id)
+
+        author = p.uploader
+        title = p.title
+        description = p.description
+        image_url = p.thumbnail
+        last_successful_sync = p.epoch
+
+        feed = Feed(
+            id=feed_id,
+            is_enabled=True,
+            source_type=source_type,
+            source_url=source_url,
+            last_successful_sync=last_successful_sync,
+            title=title,
+            subtitle=None,
+            description=description,
+            language=None,
+            author=author,
+            remote_image_url=image_url,
+        )
+
+        logger.debug(
+            "Successfully extracted Patreon feed metadata.",
+            extra={
+                "feed_id": feed_id,
+                "source_type": source_type.value,
+                "title": title,
+                "author": author,
+                "has_description": description is not None,
+                "has_image_url": image_url is not None,
+            },
+        )
+        return feed
+
+    def prepare_thumbnail_args(
+        self,
+        args: YtdlpArgs,
+    ) -> YtdlpArgs:
+        """Apply Patreon referer for thumbnail downloads."""
+        return args.referer(_PATREON_REFERER)
+
+    def prepare_downloads_info_args(
+        self,
+        args: YtdlpArgs,
+    ) -> YtdlpArgs:
+        """Apply Patreon referer and match filter for downloads metadata calls."""
+        return args.referer(_PATREON_REFERER).match_filter("vcodec")
+
+    async def _probe_duration(self, feed_id: str, entry: PatreonEntry) -> int:
+        """Probe duration using entry URLs; raise wrapped error on failure.
+
+        Order of candidates:
+        1) requested_download_urls[0]
+        2) media_url
+        3) first_format_url
+        """
+        candidate_url: str | None = None
+        candidate_source: str | None = None
+        if entry.requested_download_urls:
+            candidate_url = entry.requested_download_urls[0]
+            candidate_source = "requested_downloads"
+        elif entry.media_url:
+            candidate_url = entry.media_url
+            candidate_source = "media_url"
+        elif entry.first_format_url:
+            candidate_url = entry.first_format_url
+            candidate_source = "first_format_url"
+
+        if not candidate_url:
+            raise YtdlpPatreonDataError(
+                "No media URL candidates found for duration probing.",
+                feed_id=feed_id,
+                download_id=entry.download_id,
+            )
+
+        try:
+            logger.debug(
+                "Probing duration with ffprobe.",
+                extra={
+                    "feed_id": feed_id,
+                    "download_id": entry.download_id,
+                    "candidate_source": candidate_source or "<unknown>",
+                    "candidate_url": candidate_url,
+                },
+            )
+            duration = await self._ffprobe.get_duration_seconds_from_url(
+                candidate_url, headers={"Referer": "https://www.patreon.com"}
+            )
+        except FFProbeError as e:
+            raise YtdlpPatreonDataError(
+                "Failed to probe duration from media URL.",
+                feed_id=feed_id,
+                download_id=entry.download_id,
+            ) from e
+
+        if duration <= 0:
+            raise YtdlpPatreonDataError(
+                "Invalid duration after probing.",
+                feed_id=feed_id,
+                download_id=entry.download_id,
+            )
+
+        return duration
+
+    async def extract_download_metadata(
+        self,
+        feed_id: str,
+        ytdlp_info: YtdlpInfo,
+    ) -> Download:
+        """Extract metadata from a single Patreon post into a Download object.
+
+        Args:
+            feed_id: The feed identifier.
+            ytdlp_info: The yt-dlp metadata for a single post.
+
+        Returns:
+            A Download object parsed from the metadata.
+
+        Raises:
+            YtdlpPatreonDataError: If required metadata is missing.
+            YtdlpPatreonPostFilteredOutError: If the post was filtered out.
+        """
+        log_config = {"feed_id": feed_id}
+        logger.debug("Extracting Patreon post metadata.", extra=log_config)
+
+        entry = PatreonEntry(ytdlp_info, feed_id)
+
+        source_url = (
+            entry.webpage_url
+            or entry.original_url
+            or f"https://www.patreon.com/posts/{entry.download_id}"
+        )
+
+        published_dt = entry.timestamp
+        if published_dt is None:
+            raise YtdlpPatreonDataError(
+                "Missing published datetime.",
+                feed_id=feed_id,
+                download_id=entry.download_id,
+            )
+
+        # Determine media properties. Posts without ext are filtered out by yt-dlp.
+        ext = entry.ext
+        if not ext:
+            raise YtdlpPatreonPostFilteredOutError(feed_id, entry.download_id)
+
+        mime_type = entry.mime_type_from_ext
+        duration = entry.duration_or_default
+        if duration <= 0:
+            duration = await self._probe_duration(feed_id, entry)
+
+        parsed_download = Download(
+            feed_id=feed_id,
+            id=entry.download_id,
+            source_url=source_url,
+            title=entry.title,
+            published=published_dt,
+            ext=ext,
+            mime_type=mime_type,
+            filesize=entry.filesize,
+            duration=duration,
+            status=DownloadStatus.QUEUED,
+            remote_thumbnail_url=entry.thumbnail,
+            description=entry.description,
+            quality_info=entry.quality_info,
+        )
+
+        logger.debug(
+            "Successfully parsed Patreon post.",
+            extra={
+                "feed_id": feed_id,
+                "download_id": entry.download_id,
+                "title": entry.title,
+            },
+        )
+        return parsed_download
+
+    def prepare_media_download_args(
+        self,
+        args: YtdlpArgs,
+    ) -> YtdlpArgs:
+        """Apply Patreon referer for media download requests."""
+        return args.referer(_PATREON_REFERER)

--- a/tests/anypod/test_ffmpeg.py
+++ b/tests/anypod/test_ffmpeg.py
@@ -1,0 +1,44 @@
+# pyright: reportPrivateUsage=false
+
+"""Unit tests for FFmpeg helper."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from anypod.exceptions import FFmpegError
+from anypod.ffmpeg import FFmpeg
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec", new_callable=AsyncMock)
+async def test_ffmpeg_convert_image_to_jpg_success(
+    mock_cse: AsyncMock, tmp_path: Path
+) -> None:
+    """convert_image_to_jpg succeeds when ffmpeg returns 0."""
+    ffm = FFmpeg()
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 0
+    mock_proc.communicate.return_value = (b"", b"")
+    mock_cse.return_value = mock_proc
+
+    await ffm.convert_image_to_jpg(tmp_path / "in.png", tmp_path / "out.jpg")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec", new_callable=AsyncMock)
+async def test_ffmpeg_convert_image_to_jpg_failure(
+    mock_cse: AsyncMock, tmp_path: Path
+) -> None:
+    """convert_image_to_jpg raises FFmpegError when ffmpeg fails."""
+    ffm = FFmpeg()
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 1
+    mock_proc.communicate.return_value = (b"", b"err")
+    mock_cse.return_value = mock_proc
+
+    with pytest.raises(FFmpegError):
+        await ffm.convert_image_to_jpg(tmp_path / "in.png", tmp_path / "out.jpg")

--- a/tests/anypod/test_ffprobe.py
+++ b/tests/anypod/test_ffprobe.py
@@ -1,0 +1,71 @@
+# pyright: reportPrivateUsage=false
+
+"""Unit tests for FFProbe helper functions."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from anypod.exceptions import FFProbeError
+from anypod.ffprobe import FFProbe
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec", new_callable=AsyncMock)
+async def test_ffprobe_is_jpg_file_success(mock_cse: AsyncMock, tmp_path: Path) -> None:
+    """is_jpg_file returns True when codec is mjpeg."""
+    probe = FFProbe()
+    fake_json = b'{"streams":[{"codec_name":"mjpeg"}]}'
+
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 0
+    mock_proc.communicate.return_value = (fake_json, b"")
+    mock_cse.return_value = mock_proc
+
+    assert await probe.is_jpg_file(tmp_path / "file") is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec", new_callable=AsyncMock)
+async def test_ffprobe_is_jpg_file_failure(mock_cse: AsyncMock, tmp_path: Path) -> None:
+    """is_jpg_file raises FFProbeError when ffprobe fails."""
+    probe = FFProbe()
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 1
+    mock_proc.communicate.return_value = (b"", b"err")
+    mock_cse.return_value = mock_proc
+
+    with pytest.raises(FFProbeError):
+        await probe.is_jpg_file(tmp_path / "file")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec", new_callable=AsyncMock)
+async def test_ffprobe_duration_from_url_success(mock_cse: AsyncMock) -> None:
+    """get_duration_seconds_from_url returns int on success."""
+    probe = FFProbe()
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 0
+    mock_proc.communicate.return_value = (b"123.9", b"")
+    mock_cse.return_value = mock_proc
+
+    assert await probe.get_duration_seconds_from_url("http://x") == 123
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec", new_callable=AsyncMock)
+async def test_ffprobe_duration_from_url_error(mock_cse: AsyncMock) -> None:
+    """get_duration_seconds_from_url raises FFProbeError on failure."""
+    probe = FFProbe()
+    mock_proc = AsyncMock()
+    mock_proc.returncode = 1
+    mock_proc.communicate.return_value = (b"", b"bad")
+    mock_cse.return_value = mock_proc
+
+    with pytest.raises(FFProbeError):
+        await probe.get_duration_seconds_from_url("http://x")

--- a/tests/anypod/ytdlp_wrapper/test_patreon_handler.py
+++ b/tests/anypod/ytdlp_wrapper/test_patreon_handler.py
@@ -1,0 +1,262 @@
+"""Unit tests for PatreonHandler and related Patreon-specific functionality."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from anypod.db.types import SourceType
+from anypod.ffprobe import FFProbe
+from anypod.ytdlp_wrapper.core import YtdlpArgs, YtdlpCore, YtdlpInfo
+from anypod.ytdlp_wrapper.patreon_handler import (
+    PatreonHandler,
+    YtdlpPatreonDataError,
+    YtdlpPatreonPostFilteredOutError,
+)
+
+FEED_ID = "patreon_feed"
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture
+def ffprobe_mock() -> MagicMock:
+    """Provide a MagicMock for FFProbe."""
+    return MagicMock(spec=FFProbe)
+
+
+@pytest.fixture
+def patreon_handler(ffprobe_mock: MagicMock) -> PatreonHandler:
+    """Provide a PatreonHandler with injected FFProbe mock."""
+    return PatreonHandler(ffprobe=ffprobe_mock)
+
+
+@pytest.fixture
+def base_args() -> YtdlpArgs:
+    """Provide a basic YtdlpArgs instance for tests."""
+    return YtdlpArgs().quiet().no_warnings()
+
+
+@pytest.fixture
+def minimal_entry_data() -> dict[str, Any]:
+    """Provide minimal entry data for tests."""
+    return {
+        "id": "post123",
+        "title": "Test Post Title",
+        "timestamp": 1700000000,
+        "epoch": 1700000000,
+    }
+
+
+@pytest.fixture
+def valid_video_entry_data(minimal_entry_data: dict[str, Any]) -> dict[str, Any]:
+    """Provide valid video entry data for tests."""
+    data = minimal_entry_data.copy()
+    data.update(
+        {
+            "ext": "mp4",
+            "duration": 120,
+            "webpage_url": "https://www.patreon.com/posts/post123",
+            "thumbnail": "https://example.com/thumb.jpg",
+            "description": "Test description",
+            "channel": "Creator Channel",
+        }
+    )
+    return data
+
+
+# --- Feed metadata tests ---
+
+
+@pytest.mark.unit
+def test_extract_feed_metadata_full(
+    patreon_handler: PatreonHandler, minimal_entry_data: dict[str, Any]
+):
+    """Test extract_feed_metadata with all available metadata fields."""
+    data = minimal_entry_data.copy()
+    data.update(
+        {
+            "description": "Feed description",
+            "thumbnail": "https://example.com/feed.jpg",
+            "channel": "Creator Channel",  # should take precedence
+            "uploader": "Individual Uploader",
+        }
+    )
+    feed = patreon_handler.extract_feed_metadata(
+        FEED_ID, YtdlpInfo(data), SourceType.PLAYLIST, "https://patreon.com/creator"
+    )
+
+    assert feed.id == FEED_ID
+    assert feed.title == data["title"]
+    assert feed.description == data["description"]
+    assert feed.author == "Creator Channel"  # channel via uploader accessor
+    assert feed.remote_image_url == data["thumbnail"]
+
+
+@pytest.mark.unit
+def test_extract_feed_metadata_minimal(
+    patreon_handler: PatreonHandler, minimal_entry_data: dict[str, Any]
+):
+    """Test extract_feed_metadata with minimal metadata."""
+    feed = patreon_handler.extract_feed_metadata(
+        FEED_ID,
+        YtdlpInfo(minimal_entry_data),
+        SourceType.UNKNOWN,
+        "https://patreon.com/x",
+    )
+    assert feed.id == FEED_ID
+    assert feed.source_type == SourceType.UNKNOWN
+    assert feed.title == minimal_entry_data["title"]
+    assert feed.author is None
+    assert feed.description is None
+    assert feed.remote_image_url is None
+
+
+# --- Download metadata tests ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_extract_download_metadata_success_with_duration(
+    patreon_handler: PatreonHandler,
+    ffprobe_mock: MagicMock,
+    valid_video_entry_data: dict[str, Any],
+):
+    """Test extract_download_metadata with duration."""
+    download = await patreon_handler.extract_download_metadata(
+        FEED_ID, YtdlpInfo(valid_video_entry_data)
+    )
+    assert download.id == valid_video_entry_data["id"]
+    assert download.duration == valid_video_entry_data["duration"]
+    ffprobe_mock.get_duration_seconds_from_url.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_extract_download_metadata_probes_duration_when_missing(
+    patreon_handler: PatreonHandler,
+    ffprobe_mock: MagicMock,
+    minimal_entry_data: dict[str, Any],
+):
+    """Test extract_download_metadata with duration missing."""
+    data = minimal_entry_data.copy()
+    data.update(
+        {
+            "ext": "mp4",
+            "duration": 0,
+            # preferred candidate comes from requested_downloads
+            "requested_downloads": [
+                {"url": "https://mux.com/video.mp4"},
+            ],
+        }
+    )
+    ffprobe_mock.get_duration_seconds_from_url = AsyncMock(return_value=234)
+
+    download = await patreon_handler.extract_download_metadata(FEED_ID, YtdlpInfo(data))
+
+    assert download.duration == 234
+    ffprobe_mock.get_duration_seconds_from_url.assert_awaited_once()
+    args, kwargs = ffprobe_mock.get_duration_seconds_from_url.await_args
+    assert args[0] == "https://mux.com/video.mp4"
+    assert kwargs["headers"]["Referer"] == "https://www.patreon.com"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_extract_download_metadata_filtered_when_ext_missing(
+    patreon_handler: PatreonHandler,
+    minimal_entry_data: dict[str, Any],
+):
+    """Test extract_download_metadata with ext missing."""
+    with pytest.raises(YtdlpPatreonPostFilteredOutError):
+        await patreon_handler.extract_download_metadata(
+            FEED_ID, YtdlpInfo(minimal_entry_data)
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_extract_download_metadata_error_when_timestamp_missing(
+    patreon_handler: PatreonHandler,
+    valid_video_entry_data: dict[str, Any],
+):
+    """Test extract_download_metadata with timestamp missing."""
+    data = valid_video_entry_data.copy()
+    data.pop("timestamp")
+    with pytest.raises(YtdlpPatreonDataError) as e:
+        await patreon_handler.extract_download_metadata(FEED_ID, YtdlpInfo(data))
+    assert e.value.feed_id == FEED_ID
+    assert e.value.download_id == data["id"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_extract_download_metadata_error_when_mime_unknown(
+    patreon_handler: PatreonHandler,
+    valid_video_entry_data: dict[str, Any],
+):
+    """Test extract_download_metadata with mime unknown."""
+    data = valid_video_entry_data.copy()
+    data["ext"] = "totallyfakeext"
+    with pytest.raises(YtdlpPatreonDataError) as e:
+        await patreon_handler.extract_download_metadata(FEED_ID, YtdlpInfo(data))
+    assert e.value.feed_id == FEED_ID
+    assert e.value.download_id == data["id"]
+
+
+# --- Determine fetch strategy tests ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch.object(YtdlpCore, "extract_playlist_info", new_callable=AsyncMock)
+async def test_determine_fetch_strategy_playlist(
+    mock_extract_playlist_info: AsyncMock,
+    patreon_handler: PatreonHandler,
+    base_args: YtdlpArgs,
+):
+    """Test determine_fetch_strategy with playlist."""
+    initial_url = "https://patreon.com/creator"
+    mock_extract_playlist_info.return_value = YtdlpInfo(
+        {
+            "extractor": "patreon:campaign",
+            "_type": "playlist",
+            "webpage_url": initial_url,
+            "id": "123",
+            "epoch": 1700000000,
+            "title": "Creator",
+        }
+    )
+    fetch_url, st = await patreon_handler.determine_fetch_strategy(
+        FEED_ID, initial_url, base_args
+    )
+    assert fetch_url == initial_url
+    assert st == SourceType.PLAYLIST
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch.object(YtdlpCore, "extract_playlist_info", new_callable=AsyncMock)
+async def test_determine_fetch_strategy_single(
+    mock_extract_playlist_info: AsyncMock,
+    patreon_handler: PatreonHandler,
+    base_args: YtdlpArgs,
+):
+    """Test determine_fetch_strategy with single video."""
+    initial_url = "https://patreon.com/posts/123"
+    mock_extract_playlist_info.return_value = YtdlpInfo(
+        {
+            "extractor": "patreon",
+            "_type": "video",
+            "webpage_url": initial_url,
+            "id": "123",
+            "epoch": 1700000000,
+            "title": "Post",
+        }
+    )
+    fetch_url, st = await patreon_handler.determine_fetch_strategy(
+        FEED_ID, initial_url, base_args
+    )
+    assert fetch_url == initial_url
+    assert st == SourceType.SINGLE_VIDEO

--- a/tests/anypod/ytdlp_wrapper/test_youtube_handler.py
+++ b/tests/anypod/ytdlp_wrapper/test_youtube_handler.py
@@ -147,12 +147,13 @@ def test_extract_feed_metadata_minimal_data(
 
 
 @pytest.mark.unit
-def test_parse_single_video_entry_success_basic(
+@pytest.mark.asyncio
+async def test_parse_single_video_entry_success_basic(
     youtube_handler: YoutubeHandler, valid_video_entry_data: dict[str, Any]
 ):
     """Tests successful parsing of a basic, valid video entry."""
     ytdlp_info = YtdlpInfo(valid_video_entry_data)
-    download = youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
+    download = await youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
 
     assert isinstance(download, Download)
     assert download.id == valid_video_entry_data["id"]
@@ -172,14 +173,15 @@ def test_parse_single_video_entry_success_basic(
 
 
 @pytest.mark.unit
-def test_parse_single_video_entry_success_no_description(
+@pytest.mark.asyncio
+async def test_parse_single_video_entry_success_no_description(
     youtube_handler: YoutubeHandler, valid_video_entry_data: dict[str, Any]
 ):
     """Tests successful parsing when description is missing."""
     del valid_video_entry_data["description"]
     ytdlp_info = YtdlpInfo(valid_video_entry_data)
 
-    download = youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
+    download = await youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
 
     assert download.description is None
 
@@ -202,7 +204,8 @@ def test_parse_single_video_entry_success_no_description(
         (".live", "application/octet-stream"),
     ],
 )
-def test_parse_single_video_entry_mime_type_mapping(
+@pytest.mark.asyncio
+async def test_parse_single_video_entry_mime_type_mapping(
     youtube_handler: YoutubeHandler,
     valid_video_entry_data: dict[str, Any],
     ext: str,
@@ -212,13 +215,14 @@ def test_parse_single_video_entry_mime_type_mapping(
     valid_video_entry_data["ext"] = ext
     ytdlp_info = YtdlpInfo(valid_video_entry_data)
 
-    download = youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
+    download = await youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
 
     assert download.mime_type == expected_mime
 
 
 @pytest.mark.unit
-def test_parse_single_video_entry_mime_type_unknown_type(
+@pytest.mark.asyncio
+async def test_parse_single_video_entry_mime_type_unknown_type(
     youtube_handler: YoutubeHandler, valid_video_entry_data: dict[str, Any]
 ):
     """Tests error for unknown extensions."""
@@ -226,7 +230,7 @@ def test_parse_single_video_entry_mime_type_unknown_type(
     ytdlp_info = YtdlpInfo(valid_video_entry_data)
 
     with pytest.raises(YtdlpYoutubeDataError) as exc_info:
-        youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
+        await youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
 
     assert exc_info.value.feed_id == FEED_ID
     assert exc_info.value.download_id == valid_video_entry_data["id"]
@@ -235,7 +239,8 @@ def test_parse_single_video_entry_mime_type_unknown_type(
 
 
 @pytest.mark.unit
-def test_parse_single_video_entry_success_with_upload_date(
+@pytest.mark.asyncio
+async def test_parse_single_video_entry_success_with_upload_date(
     youtube_handler: YoutubeHandler,
     valid_video_entry_data: dict[str, Any],
 ):
@@ -245,13 +250,14 @@ def test_parse_single_video_entry_success_with_upload_date(
     valid_video_entry_data["upload_date"] = expected_published.strftime("%Y%m%d")
     ytdlp_info = YtdlpInfo(valid_video_entry_data)
 
-    download = youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
+    download = await youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
 
     assert download.published == expected_published
 
 
 @pytest.mark.unit
-def test_parse_single_video_entry_success_with_release_timestamp(
+@pytest.mark.asyncio
+async def test_parse_single_video_entry_success_with_release_timestamp(
     youtube_handler: YoutubeHandler,
     valid_video_entry_data: dict[str, Any],
 ):
@@ -261,13 +267,14 @@ def test_parse_single_video_entry_success_with_release_timestamp(
     valid_video_entry_data["release_timestamp"] = expected_published.timestamp()
     ytdlp_info = YtdlpInfo(valid_video_entry_data)
 
-    download = youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
+    download = await youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
 
     assert download.published == expected_published
 
 
 @pytest.mark.unit
-def test_parse_single_video_entry_live_upcoming_video(
+@pytest.mark.asyncio
+async def test_parse_single_video_entry_live_upcoming_video(
     youtube_handler: YoutubeHandler,
     valid_video_entry_data: dict[str, Any],
 ):
@@ -276,7 +283,7 @@ def test_parse_single_video_entry_live_upcoming_video(
     valid_video_entry_data["live_status"] = "is_upcoming"
     ytdlp_info = YtdlpInfo(valid_video_entry_data)
 
-    download = youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
+    download = await youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
 
     assert download.status == DownloadStatus.UPCOMING
     assert download.ext == "live"
@@ -286,7 +293,8 @@ def test_parse_single_video_entry_live_upcoming_video(
 
 
 @pytest.mark.unit
-def test_parse_single_video_entry_source_url_priority(
+@pytest.mark.asyncio
+async def test_parse_single_video_entry_source_url_priority(
     youtube_handler: YoutubeHandler, valid_video_entry_data: dict[str, Any]
 ):
     """Tests the priority for source_url: webpage_url > original_url > default."""
@@ -297,32 +305,33 @@ def test_parse_single_video_entry_source_url_priority(
     # Case 1: webpage_url present
     entry1_data = {**entry_base_data, "webpage_url": "https://webpage.url"}
     ytdlp_info1 = YtdlpInfo(entry1_data)
-    download1 = youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info1)
+    download1 = await youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info1)
     assert download1.source_url == "https://webpage.url"
 
     # Case 2: original_url present, webpage_url missing
     entry2_data = {**entry_base_data, "original_url": "https://original.url"}
     ytdlp_info2 = YtdlpInfo(entry2_data)
-    download2 = youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info2)
+    download2 = await youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info2)
     assert download2.source_url == "https://original.url"
 
     # Case 3: Both missing, defaults to youtube watch URL
     entry3_data = entry_base_data.copy()
     ytdlp_info3 = YtdlpInfo(entry3_data)
-    download3 = youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info3)
+    download3 = await youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info3)
     assert (
         download3.source_url == f"https://www.youtube.com/watch?v={entry3_data['id']}"
     )
 
 
 @pytest.mark.unit
-def test_parse_single_video_entry_duration_as_int(
+@pytest.mark.asyncio
+async def test_parse_single_video_entry_duration_as_int(
     youtube_handler: YoutubeHandler, valid_video_entry_data: dict[str, Any]
 ):
     """Tests parsing when duration is an integer."""
     valid_video_entry_data["duration"] = 120
     ytdlp_info = YtdlpInfo(valid_video_entry_data)
-    download = youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
+    download = await youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
     assert download.duration == 120
 
 
@@ -340,7 +349,8 @@ def test_parse_single_video_entry_error_missing_id(
 
 
 @pytest.mark.unit
-def test_parse_single_video_entry_error_video_filtered_out(
+@pytest.mark.asyncio
+async def test_parse_single_video_entry_error_video_filtered_out(
     youtube_handler: YoutubeHandler,
     valid_video_entry_data: dict[str, Any],
 ):
@@ -349,7 +359,7 @@ def test_parse_single_video_entry_error_video_filtered_out(
     ytdlp_info = YtdlpInfo(valid_video_entry_data)
 
     with pytest.raises(YtdlpYoutubeVideoFilteredOutError) as e:
-        youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
+        await youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
     assert e.value.feed_id == FEED_ID
     assert e.value.download_id == valid_video_entry_data["id"]
 
@@ -359,7 +369,8 @@ def test_parse_single_video_entry_error_video_filtered_out(
     "bad_title",
     [None, "[Deleted video]", "[Private video]"],
 )
-def test_parse_single_video_entry_error_invalid_title(
+@pytest.mark.asyncio
+async def test_parse_single_video_entry_error_invalid_title(
     youtube_handler: YoutubeHandler,
     bad_title: str | None,
     valid_video_entry_data: dict[str, Any],
@@ -370,7 +381,7 @@ def test_parse_single_video_entry_error_invalid_title(
     ytdlp_info = YtdlpInfo(valid_video_entry_data)
 
     with pytest.raises(YtdlpYoutubeDataError) as e:
-        youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
+        await youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
 
     if bad_title is None:
         assert "Failed to parse YouTube entry." in str(e.value)
@@ -380,7 +391,8 @@ def test_parse_single_video_entry_error_invalid_title(
 
 
 @pytest.mark.unit
-def test_parse_single_video_entry_error_missing_all_dts(
+@pytest.mark.asyncio
+async def test_parse_single_video_entry_error_missing_all_dts(
     youtube_handler: YoutubeHandler,
     valid_video_entry_data: dict[str, Any],
 ):
@@ -389,7 +401,7 @@ def test_parse_single_video_entry_error_missing_all_dts(
     ytdlp_info = YtdlpInfo(valid_video_entry_data)
 
     with pytest.raises(YtdlpYoutubeDataError) as e:
-        youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
+        await youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
     assert "Missing published datetime" in str(e.value)
 
 
@@ -403,7 +415,8 @@ def test_parse_single_video_entry_error_missing_all_dts(
         ("release_timestamp", "not-a-number", "Failed to parse YouTube entry."),
     ],
 )
-def test_parse_single_video_entry_error_invalid_date_formats_for_dts(
+@pytest.mark.asyncio
+async def test_parse_single_video_entry_error_invalid_date_formats_for_dts(
     youtube_handler: YoutubeHandler,
     key: str,
     bad_value: Any,
@@ -416,13 +429,14 @@ def test_parse_single_video_entry_error_invalid_date_formats_for_dts(
     ytdlp_info = YtdlpInfo(valid_video_entry_data)
 
     with pytest.raises(YtdlpYoutubeDataError) as e:
-        youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
+        await youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
     assert expected_msg_part in str(e.value)
     assert e.value.download_id == valid_video_entry_data["id"]
 
 
 @pytest.mark.unit
-def test_parse_single_video_entry_error_missing_extension(
+@pytest.mark.asyncio
+async def test_parse_single_video_entry_error_missing_extension(
     youtube_handler: YoutubeHandler,
     valid_video_entry_data: dict[str, Any],
 ):
@@ -431,7 +445,7 @@ def test_parse_single_video_entry_error_missing_extension(
     ytdlp_info = YtdlpInfo(valid_video_entry_data)
 
     with pytest.raises(YtdlpYoutubeVideoFilteredOutError) as e:
-        youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
+        await youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
     assert e.value.feed_id == FEED_ID
     assert e.value.download_id == valid_video_entry_data["id"]
 
@@ -446,7 +460,8 @@ def test_parse_single_video_entry_error_missing_extension(
         ({"value": 60}, "Failed to parse YouTube entry."),
     ],
 )
-def test_parse_single_video_entry_error_invalid_duration(
+@pytest.mark.asyncio
+async def test_parse_single_video_entry_error_invalid_duration(
     youtube_handler: YoutubeHandler,
     bad_duration: Any,
     expected_msg_part: str,
@@ -457,7 +472,7 @@ def test_parse_single_video_entry_error_invalid_duration(
     ytdlp_info = YtdlpInfo(valid_video_entry_data)
 
     with pytest.raises(YtdlpYoutubeDataError) as e:
-        youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
+        await youtube_handler.extract_download_metadata(FEED_ID, ytdlp_info)
     assert expected_msg_part in str(e.value)
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,6 +16,8 @@ from anypod.db import AppStateDatabase
 from anypod.db.download_db import DownloadDatabase
 from anypod.db.feed_db import FeedDatabase
 from anypod.db.sqlalchemy_core import SqlalchemyCore
+from anypod.ffmpeg import FFmpeg
+from anypod.ffprobe import FFProbe
 from anypod.file_manager import FileManager
 from anypod.image_downloader import ImageDownloader
 from anypod.path_manager import PathManager
@@ -127,15 +129,30 @@ def ytdlp_wrapper(path_manager: PathManager, db_core: SqlalchemyCore) -> YtdlpWr
 
 
 @pytest.fixture
+def ffprobe() -> FFProbe:
+    """Provide an FFProbe instance for integration tests."""
+    return FFProbe()
+
+
+@pytest.fixture
+def ffmpeg() -> FFmpeg:
+    """Provide an FFmpeg instance for integration tests."""
+    return FFmpeg()
+
+
+@pytest.fixture
 def image_downloader(
-    path_manager: PathManager, ytdlp_wrapper: YtdlpWrapper
+    path_manager: PathManager,
+    ytdlp_wrapper: YtdlpWrapper,
+    ffprobe: FFProbe,
+    ffmpeg: FFmpeg,
 ) -> ImageDownloader:
     """Provide an ImageDownloader instance with shared components.
 
     Returns:
         ImageDownloader instance configured with test path manager and ytdlp wrapper.
     """
-    return ImageDownloader(path_manager, ytdlp_wrapper)
+    return ImageDownloader(path_manager, ytdlp_wrapper, ffprobe=ffprobe, ffmpeg=ffmpeg)
 
 
 @pytest.fixture

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,6 +23,7 @@ from anypod.image_downloader import ImageDownloader
 from anypod.path_manager import PathManager
 from anypod.rss.rss_feed import RSSFeedGenerator
 from anypod.server.app import create_admin_app, create_app
+from anypod.ytdlp_wrapper.base_handler import HandlerSelector
 from anypod.ytdlp_wrapper.ytdlp_wrapper import YtdlpWrapper
 
 
@@ -112,7 +113,21 @@ def download_db(db_core: SqlalchemyCore) -> DownloadDatabase:
 
 
 @pytest.fixture
-def ytdlp_wrapper(path_manager: PathManager, db_core: SqlalchemyCore) -> YtdlpWrapper:
+def handler_selector(ffprobe: FFProbe) -> HandlerSelector:
+    """Provide a HandlerSelector instance with shared FFProbe.
+
+    Returns:
+        HandlerSelector instance configured with test FFProbe.
+    """
+    return HandlerSelector(ffprobe)
+
+
+@pytest.fixture
+def ytdlp_wrapper(
+    path_manager: PathManager,
+    db_core: SqlalchemyCore,
+    handler_selector: HandlerSelector,
+) -> YtdlpWrapper:
     """Provide a YtdlpWrapper instance with shared directories.
 
     Returns:
@@ -125,6 +140,7 @@ def ytdlp_wrapper(path_manager: PathManager, db_core: SqlalchemyCore) -> YtdlpWr
         app_state_db=app_state_db,
         yt_channel="stable",
         yt_update_freq=timedelta(hours=12),
+        handler_selector=handler_selector,
     )
 
 

--- a/tests/integration/test_integration_ff.py
+++ b/tests/integration/test_integration_ff.py
@@ -1,0 +1,105 @@
+# pyright: reportPrivateUsage=false
+
+"""Integration tests for FFProbe and FFmpeg utilities.
+
+Covers real ffprobe format detection and ffmpeg image conversion, plus
+duration detection from direct media URLs for individual YouTube videos.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from anypod.ffmpeg import FFmpeg
+from anypod.ffprobe import FFProbe
+from anypod.ytdlp_wrapper.core import YtdlpArgs, YtdlpCore
+
+BIG_BUCK_BUNNY_SHORT_URL = "https://youtu.be/aqz-KE-bpKQ"
+BIG_BUCK_BUNNY_EXPECTED_DURATION_SECONDS = 635  # Retrieved via yt-dlp --print duration
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_is_jpg_file_detects_jpg(
+    ffprobe: FFProbe, test_images: dict[str, Path]
+) -> None:
+    """Format detection correctly identifies JPG files using real ffprobe."""
+    result = await ffprobe.is_jpg_file(test_images["jpg"])
+    assert result is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_is_jpg_file_detects_non_jpg(
+    ffprobe: FFProbe, test_images: dict[str, Path]
+) -> None:
+    """Format detection correctly identifies non-JPG files using real ffprobe."""
+    result = await ffprobe.is_jpg_file(test_images["png"])
+    assert result is False
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ffmpeg_convert_image_to_jpg(
+    ffmpeg: FFmpeg, ffprobe: FFProbe, test_images: dict[str, Path], tmp_path: Path
+) -> None:
+    """Image conversion succeeds with real ffmpeg and results in a valid JPG file."""
+    output_path = tmp_path / "converted.jpg"
+    await ffmpeg.convert_image_to_jpg(test_images["png"], output_path)
+
+    assert output_path.exists()
+    assert output_path.stat().st_size > 0
+
+    # Verify output is actually JPG
+    is_jpg = await ffprobe.is_jpg_file(output_path)
+    assert is_jpg is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def _get_direct_media_url_for_video(video_url: str) -> str:
+    """Return a direct media URL for the given YouTube video using yt-dlp.
+
+    Uses skip-download + dump-json and extracts the first format URL, which is
+    sufficient for duration probing purposes.
+    """
+    args = YtdlpArgs().skip_download().dump_json()
+    infos = await YtdlpCore.extract_downloads_info(args, video_url)
+    assert infos, "yt-dlp did not return any entries for the video URL"
+    info = infos[0]
+    formats = info.get("formats", list[dict[str, Any]])
+    assert formats, "no formats found in yt-dlp output"
+
+    candidates: list[str] = []
+    for fmt in formats:  # type: ignore
+        protocol = fmt.get("protocol")
+        ext = fmt.get("ext")
+        url = fmt.get("url")
+        has_manifest = fmt.get("manifest_url") is not None
+        # Prefer progressive HTTPS URLs (avoid HLS/DASH manifests)
+        if (
+            isinstance(url, str)
+            and not has_manifest
+            and protocol in ("https", "http")
+            and isinstance(ext, str)
+            and ext in ("mp4", "m4a", "webm")
+        ):
+            candidates.append(url)
+
+    # Prefer MP4 if available for better container-level metadata
+    mp4_candidates = [u for u in candidates if u.endswith(".mp4")]
+    if mp4_candidates:
+        return mp4_candidates[0]
+    assert candidates, "no direct progressive media URL candidates found"
+    return candidates[0]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ffprobe_get_duration_from_url_basic(ffprobe: FFProbe) -> None:
+    """FFProbe can obtain duration (in seconds) from a direct media URL."""
+    direct_url = await _get_direct_media_url_for_video(BIG_BUCK_BUNNY_SHORT_URL)
+    duration = await ffprobe.get_duration_seconds_from_url(direct_url)
+    # ffprobe can report fractional seconds. Allow 1s tolerance.
+    assert abs(duration - BIG_BUCK_BUNNY_EXPECTED_DURATION_SECONDS) <= 1

--- a/tests/integration/test_integration_image_downloader.py
+++ b/tests/integration/test_integration_image_downloader.py
@@ -11,57 +11,11 @@ import httpx
 import pytest
 import respx
 
+from anypod.ffprobe import FFProbe
 from anypod.image_downloader import ImageDownloader
 from anypod.path_manager import PathManager
 
 # --- Integration Tests ---
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_is_jpg_format_detects_jpg(
-    image_downloader: ImageDownloader, test_images: dict[str, Path]
-) -> None:
-    """Format detection correctly identifies JPG files using real ffprobe."""
-    result = await image_downloader._is_jpg_format(
-        test_images["jpg"], "test_feed", "http://example.com/test.jpg"
-    )
-    assert result is True
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_is_jpg_format_detects_non_jpg(
-    image_downloader: ImageDownloader, test_images: dict[str, Path]
-) -> None:
-    """Format detection correctly identifies non-JPG files using real ffprobe."""
-    result = await image_downloader._is_jpg_format(
-        test_images["png"], "test_feed", "http://example.com/test.png"
-    )
-    assert result is False
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_convert_to_jpg_success(
-    image_downloader: ImageDownloader, test_images: dict[str, Path], tmp_path: Path
-) -> None:
-    """Image conversion succeeds with real ffmpeg."""
-    output_path = tmp_path / "converted.jpg"
-
-    await image_downloader._convert_to_jpg(
-        test_images["png"], output_path, "test_feed", "http://example.com/test.png"
-    )
-
-    # Verify output file was created and is a valid JPG
-    assert output_path.exists()
-    assert output_path.stat().st_size > 0
-
-    # Verify it's actually a JPG by checking with our format detection
-    result = await image_downloader._is_jpg_format(
-        output_path, "test_feed", "http://example.com/test.png"
-    )
-    assert result is True
 
 
 @pytest.mark.integration
@@ -96,6 +50,7 @@ async def test_download_feed_image_direct_png_with_conversion(
     image_downloader: ImageDownloader,
     path_manager: PathManager,
     test_images: dict[str, Path],
+    ffprobe: FFProbe,
 ) -> None:
     """Direct download of PNG file triggers conversion to JPG using real ffmpeg."""
     feed_id = "feed123"
@@ -114,5 +69,5 @@ async def test_download_feed_image_direct_png_with_conversion(
     assert expected_path.stat().st_size > 0
 
     # Verify the final file is actually in JPG format
-    is_jpg = await image_downloader._is_jpg_format(expected_path, feed_id, url)
+    is_jpg = await ffprobe.is_jpg_file(expected_path)
     assert is_jpg is True

--- a/tests/integration/test_integration_state_reconciler.py
+++ b/tests/integration/test_integration_state_reconciler.py
@@ -20,6 +20,8 @@ from anypod.config.types import (
 from anypod.data_coordinator.pruner import Pruner
 from anypod.db import DownloadDatabase, FeedDatabase
 from anypod.db.types import Download, DownloadStatus, Feed, SourceType
+from anypod.ffmpeg import FFmpeg
+from anypod.ffprobe import FFProbe
 from anypod.file_manager import FileManager
 from anypod.image_downloader import ImageDownloader
 from anypod.path_manager import PathManager
@@ -43,9 +45,13 @@ def state_reconciler(
     pruner: Pruner,
     file_manager: FileManager,
     path_manager: PathManager,
+    ffprobe: FFProbe,
+    ffmpeg: FFmpeg,
 ) -> StateReconciler:
     """Provides a StateReconciler instance with real dependencies."""
-    image_downloader = ImageDownloader(path_manager, ytdlp_wrapper)
+    image_downloader = ImageDownloader(
+        path_manager, ytdlp_wrapper, ffprobe=ffprobe, ffmpeg=ffmpeg
+    )
     return StateReconciler(
         file_manager,
         image_downloader,

--- a/uv.lock
+++ b/uv.lock
@@ -94,7 +94,7 @@ dev = [
     { name = "pytest-xdist" },
     { name = "respx" },
     { name = "ruff" },
-    { name = "yt-dlp" },
+    { name = "yt-dlp", extra = ["default"] },
 ]
 
 [package.metadata]
@@ -129,7 +129,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.7.0" },
     { name = "respx", specifier = ">=0.22.0" },
     { name = "ruff", specifier = ">=0.11.7" },
-    { name = "yt-dlp", specifier = ">=2025.8.22" },
+    { name = "yt-dlp", extras = ["default"], specifier = ">=2025.8.22" },
 ]
 
 [[package]]
@@ -145,12 +145,94 @@ wheels = [
 ]
 
 [[package]]
-name = "certifi"
-version = "2025.8.3"
+name = "brotli"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/67/960ebe6bf230a96cda2e0abcf73af550ec4f090005363542f0765df162e0/certifi-2025.8.3.tar.gz", hash = "sha256:e564105f78ded564e3ae7c923924435e1daa7463faeab5bb932bc53ffae63407", size = 162386, upload-time = "2025-08-03T03:07:47.08Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/c2/f9e977608bdf958650638c3f1e28f85a1b075f075ebbe77db8555463787b/Brotli-1.1.0.tar.gz", hash = "sha256:81de08ac11bcb85841e440c13611c00b67d3bf82698314928d0b676362546724", size = 7372270, upload-time = "2023-09-07T14:05:41.643Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/48/1549795ba7742c948d2ad169c1c8cdbae65bc450d6cd753d124b17c8cd32/certifi-2025.8.3-py3-none-any.whl", hash = "sha256:f6c12493cfb1b06ba2ff328595af9350c65d6644968e5d3a2ffd78699af217a5", size = 161216, upload-time = "2025-08-03T03:07:45.777Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/9f/fb37bb8ffc52a8da37b1c03c459a8cd55df7a57bdccd8831d500e994a0ca/Brotli-1.1.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8bf32b98b75c13ec7cf774164172683d6e7891088f6316e54425fde1efc276d5", size = 815681, upload-time = "2024-10-18T12:32:34.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b3/dbd332a988586fefb0aa49c779f59f47cae76855c2d00f450364bb574cac/Brotli-1.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7bc37c4d6b87fb1017ea28c9508b36bbcb0c3d18b4260fcdf08b200c74a6aee8", size = 422475, upload-time = "2024-10-18T12:32:36.485Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/80/6aaddc2f63dbcf2d93c2d204e49c11a9ec93a8c7c63261e2b4bd35198283/Brotli-1.1.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c0ef38c7a7014ffac184db9e04debe495d317cc9c6fb10071f7fefd93100a4f", size = 2906173, upload-time = "2024-10-18T12:32:37.978Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/1d/e6ca79c96ff5b641df6097d299347507d39a9604bde8915e76bf026d6c77/Brotli-1.1.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91d7cc2a76b5567591d12c01f019dd7afce6ba8cba6571187e21e2fc418ae648", size = 2943803, upload-time = "2024-10-18T12:32:39.606Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/a3/d98d2472e0130b7dd3acdbb7f390d478123dbf62b7d32bda5c830a96116d/Brotli-1.1.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a93dde851926f4f2678e704fadeb39e16c35d8baebd5252c9fd94ce8ce68c4a0", size = 2918946, upload-time = "2024-10-18T12:32:41.679Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a5/c69e6d272aee3e1423ed005d8915a7eaa0384c7de503da987f2d224d0721/Brotli-1.1.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f0db75f47be8b8abc8d9e31bc7aad0547ca26f24a54e6fd10231d623f183d089", size = 2845707, upload-time = "2024-10-18T12:32:43.478Z" },
+    { url = "https://files.pythonhosted.org/packages/58/9f/4149d38b52725afa39067350696c09526de0125ebfbaab5acc5af28b42ea/Brotli-1.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6967ced6730aed543b8673008b5a391c3b1076d834ca438bbd70635c73775368", size = 2936231, upload-time = "2024-10-18T12:32:45.224Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5a/145de884285611838a16bebfdb060c231c52b8f84dfbe52b852a15780386/Brotli-1.1.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7eedaa5d036d9336c95915035fb57422054014ebdeb6f3b42eac809928e40d0c", size = 2848157, upload-time = "2024-10-18T12:32:46.894Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ae/408b6bfb8525dadebd3b3dd5b19d631da4f7d46420321db44cd99dcf2f2c/Brotli-1.1.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d487f5432bf35b60ed625d7e1b448e2dc855422e87469e3f450aa5552b0eb284", size = 3035122, upload-time = "2024-10-18T12:32:48.844Z" },
+    { url = "https://files.pythonhosted.org/packages/af/85/a94e5cfaa0ca449d8f91c3d6f78313ebf919a0dbd55a100c711c6e9655bc/Brotli-1.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:832436e59afb93e1836081a20f324cb185836c617659b07b129141a8426973c7", size = 2930206, upload-time = "2024-10-18T12:32:51.198Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f0/a61d9262cd01351df22e57ad7c34f66794709acab13f34be2675f45bf89d/Brotli-1.1.0-cp313-cp313-win32.whl", hash = "sha256:43395e90523f9c23a3d5bdf004733246fba087f2948f87ab28015f12359ca6a0", size = 333804, upload-time = "2024-10-18T12:32:52.661Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/c1/ec214e9c94000d1c1974ec67ced1c970c148aa6b8d8373066123fc3dbf06/Brotli-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:9011560a466d2eb3f5a6e4929cf4a09be405c64154e12df0dd72713f6500e32b", size = 358517, upload-time = "2024-10-18T12:32:54.066Z" },
+]
+
+[[package]]
+name = "brotlicffi"
+version = "1.1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/9d/70caa61192f570fcf0352766331b735afa931b4c6bc9a348a0925cc13288/brotlicffi-1.1.0.0.tar.gz", hash = "sha256:b77827a689905143f87915310b93b273ab17888fd43ef350d4832c4a71083c13", size = 465192, upload-time = "2023-09-14T14:22:40.707Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/11/7b96009d3dcc2c931e828ce1e157f03824a69fb728d06bfd7b2fc6f93718/brotlicffi-1.1.0.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9b7ae6bd1a3f0df532b6d67ff674099a96d22bc0948955cb338488c31bfb8851", size = 453786, upload-time = "2023-09-14T14:21:57.72Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/e6/a8f46f4a4ee7856fbd6ac0c6fb0dc65ed181ba46cd77875b8d9bbe494d9e/brotlicffi-1.1.0.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:19ffc919fa4fc6ace69286e0a23b3789b4219058313cf9b45625016bf7ff996b", size = 2911165, upload-time = "2023-09-14T14:21:59.613Z" },
+    { url = "https://files.pythonhosted.org/packages/be/20/201559dff14e83ba345a5ec03335607e47467b6633c210607e693aefac40/brotlicffi-1.1.0.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9feb210d932ffe7798ee62e6145d3a757eb6233aa9a4e7db78dd3690d7755814", size = 2927895, upload-time = "2023-09-14T14:22:01.22Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/15/695b1409264143be3c933f708a3f81d53c4a1e1ebbc06f46331decbf6563/brotlicffi-1.1.0.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:84763dbdef5dd5c24b75597a77e1b30c66604725707565188ba54bab4f114820", size = 2851834, upload-time = "2023-09-14T14:22:03.571Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/40/b961a702463b6005baf952794c2e9e0099bde657d0d7e007f923883b907f/brotlicffi-1.1.0.0-cp37-abi3-win32.whl", hash = "sha256:1b12b50e07c3911e1efa3a8971543e7648100713d4e0971b13631cce22c587eb", size = 341731, upload-time = "2023-09-14T14:22:05.74Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fa/5408a03c041114ceab628ce21766a4ea882aa6f6f0a800e04ee3a30ec6b9/brotlicffi-1.1.0.0-cp37-abi3-win_amd64.whl", hash = "sha256:994a4f0681bb6c6c3b0925530a1926b7a189d878e6e5e38fae8efa47c5d9c613", size = 366783, upload-time = "2023-09-14T14:22:07.096Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2025.10.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/5b/b6ce21586237c77ce67d01dc5507039d444b630dd76611bbca2d8e5dcd91/certifi-2025.10.5.tar.gz", hash = "sha256:47c09d31ccf2acf0be3f701ea53595ee7e0b8fa08801c6624be771df09ae7b43", size = 164519, upload-time = "2025-10-05T04:12:15.808Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/37/af0d2ef3967ac0d6113837b44a4f0bfe1328c2b9763bd5b1744520e5cfed/certifi-2025.10.5-py3-none-any.whl", hash = "sha256:0f212c2744a9bb6de0c56639a6f68afe01ecd92d91f14ae897c4fe7bbeeef0de", size = 163286, upload-time = "2025-10-05T04:12:14.03Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -160,6 +242,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114, upload-time = "2023-08-12T20:38:17.776Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249, upload-time = "2023-08-12T20:38:16.269Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/2d/5fd176ceb9b2fc619e63405525573493ca23441330fcdaee6bef9460e924/charset_normalizer-3.4.3.tar.gz", hash = "sha256:6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14", size = 122371, upload-time = "2025-08-09T07:57:28.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/ca/2135ac97709b400c7654b4b764daf5c5567c2da45a30cdd20f9eefe2d658/charset_normalizer-3.4.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:14c2a87c65b351109f6abfc424cab3927b3bdece6f706e4d12faaf3d52ee5efe", size = 205326, upload-time = "2025-08-09T07:56:24.721Z" },
+    { url = "https://files.pythonhosted.org/packages/71/11/98a04c3c97dd34e49c7d247083af03645ca3730809a5509443f3c37f7c99/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41d1fc408ff5fdfb910200ec0e74abc40387bccb3252f3f27c0676731df2b2c8", size = 146008, upload-time = "2025-08-09T07:56:26.004Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/4659a4cb3c4ec146bec80c32d8bb16033752574c20b1252ee842a95d1a1e/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1bb60174149316da1c35fa5233681f7c0f9f514509b8e399ab70fea5f17e45c9", size = 159196, upload-time = "2025-08-09T07:56:27.25Z" },
+    { url = "https://files.pythonhosted.org/packages/86/9e/f552f7a00611f168b9a5865a1414179b2c6de8235a4fa40189f6f79a1753/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:30d006f98569de3459c2fc1f2acde170b7b2bd265dc1943e87e1a4efe1b67c31", size = 156819, upload-time = "2025-08-09T07:56:28.515Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/95/42aa2156235cbc8fa61208aded06ef46111c4d3f0de233107b3f38631803/charset_normalizer-3.4.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:416175faf02e4b0810f1f38bcb54682878a4af94059a1cd63b8747244420801f", size = 151350, upload-time = "2025-08-09T07:56:29.716Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a9/3865b02c56f300a6f94fc631ef54f0a8a29da74fb45a773dfd3dcd380af7/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6aab0f181c486f973bc7262a97f5aca3ee7e1437011ef0c2ec04b5a11d16c927", size = 148644, upload-time = "2025-08-09T07:56:30.984Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d9/cbcf1a2a5c7d7856f11e7ac2d782aec12bdfea60d104e60e0aa1c97849dc/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:fdabf8315679312cfa71302f9bd509ded4f2f263fb5b765cf1433b39106c3cc9", size = 160468, upload-time = "2025-08-09T07:56:32.252Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/42/6f45efee8697b89fda4d50580f292b8f7f9306cb2971d4b53f8914e4d890/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:bd28b817ea8c70215401f657edef3a8aa83c29d447fb0b622c35403780ba11d5", size = 158187, upload-time = "2025-08-09T07:56:33.481Z" },
+    { url = "https://files.pythonhosted.org/packages/70/99/f1c3bdcfaa9c45b3ce96f70b14f070411366fa19549c1d4832c935d8e2c3/charset_normalizer-3.4.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:18343b2d246dc6761a249ba1fb13f9ee9a2bcd95decc767319506056ea4ad4dc", size = 152699, upload-time = "2025-08-09T07:56:34.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ad/b0081f2f99a4b194bcbb1934ef3b12aa4d9702ced80a37026b7607c72e58/charset_normalizer-3.4.3-cp313-cp313-win32.whl", hash = "sha256:6fb70de56f1859a3f71261cbe41005f56a7842cc348d3aeb26237560bfa5e0ce", size = 99580, upload-time = "2025-08-09T07:56:35.981Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/8f/ae790790c7b64f925e5c953b924aaa42a243fb778fed9e41f147b2a5715a/charset_normalizer-3.4.3-cp313-cp313-win_amd64.whl", hash = "sha256:cf1ebb7d78e1ad8ec2a8c4732c7be2e736f6e5123a4146c5b89c9d1f585f8cef", size = 107366, upload-time = "2025-08-09T07:56:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/91/b5a06ad970ddc7a0e513112d40113e834638f4ca1120eb727a249fb2715e/charset_normalizer-3.4.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3cd35b7e8aedeb9e34c41385fda4f73ba609e561faedfae0a9e75e44ac558a15", size = 204342, upload-time = "2025-08-09T07:56:38.687Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ec/1edc30a377f0a02689342f214455c3f6c2fbedd896a1d2f856c002fc3062/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b89bc04de1d83006373429975f8ef9e7932534b8cc9ca582e4db7d20d91816db", size = 145995, upload-time = "2025-08-09T07:56:40.048Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e5/5e67ab85e6d22b04641acb5399c8684f4d37caf7558a53859f0283a650e9/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2001a39612b241dae17b4687898843f254f8748b796a2e16f1051a17078d991d", size = 158640, upload-time = "2025-08-09T07:56:41.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/e5/38421987f6c697ee3722981289d554957c4be652f963d71c5e46a262e135/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8dcfc373f888e4fb39a7bc57e93e3b845e7f462dacc008d9749568b1c4ece096", size = 156636, upload-time = "2025-08-09T07:56:43.195Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e4/5a075de8daa3ec0745a9a3b54467e0c2967daaaf2cec04c845f73493e9a1/charset_normalizer-3.4.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18b97b8404387b96cdbd30ad660f6407799126d26a39ca65729162fd810a99aa", size = 150939, upload-time = "2025-08-09T07:56:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/02/f7/3611b32318b30974131db62b4043f335861d4d9b49adc6d57c1149cc49d4/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ccf600859c183d70eb47e05a44cd80a4ce77394d1ac0f79dbd2dd90a69a3a049", size = 148580, upload-time = "2025-08-09T07:56:46.684Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/61/19b36f4bd67f2793ab6a99b979b4e4f3d8fc754cbdffb805335df4337126/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:53cd68b185d98dde4ad8990e56a58dea83a4162161b1ea9272e5c9182ce415e0", size = 159870, upload-time = "2025-08-09T07:56:47.941Z" },
+    { url = "https://files.pythonhosted.org/packages/06/57/84722eefdd338c04cf3030ada66889298eaedf3e7a30a624201e0cbe424a/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:30a96e1e1f865f78b030d65241c1ee850cdf422d869e9028e2fc1d5e4db73b92", size = 157797, upload-time = "2025-08-09T07:56:49.756Z" },
+    { url = "https://files.pythonhosted.org/packages/72/2a/aff5dd112b2f14bcc3462c312dce5445806bfc8ab3a7328555da95330e4b/charset_normalizer-3.4.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d716a916938e03231e86e43782ca7878fb602a125a91e7acb8b5112e2e96ac16", size = 152224, upload-time = "2025-08-09T07:56:51.369Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8c/9839225320046ed279c6e839d51f028342eb77c91c89b8ef2549f951f3ec/charset_normalizer-3.4.3-cp314-cp314-win32.whl", hash = "sha256:c6dbd0ccdda3a2ba7c2ecd9d77b37f3b5831687d8dc1b6ca5f56a4880cc7b7ce", size = 100086, upload-time = "2025-08-09T07:56:52.722Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7a/36fbcf646e41f710ce0a563c1c9a343c6edf9be80786edeb15b6f62e17db/charset_normalizer-3.4.3-cp314-cp314-win_amd64.whl", hash = "sha256:73dc19b562516fc9bcf6e5d6e596df0b4eb98d87e4f79f3ae71840e6ed21361c", size = 107400, upload-time = "2025-08-09T07:56:55.172Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1f/f041989e93b001bc4e44bb1669ccdcf54d3f00e628229a85b08d330615c5/charset_normalizer-3.4.3-py3-none-any.whl", hash = "sha256:ce571ab16d890d23b5c278547ba694193a45011ff86a9162a71307ed9f86759a", size = 53175, upload-time = "2025-08-09T07:57:26.864Z" },
 ]
 
 [[package]]
@@ -398,11 +511,11 @@ wheels = [
 
 [[package]]
 name = "identify"
-version = "2.6.14"
+version = "2.6.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/c4/62963f25a678f6a050fb0505a65e9e726996171e6dbe1547f79619eefb15/identify-2.6.14.tar.gz", hash = "sha256:663494103b4f717cb26921c52f8751363dc89db64364cd836a9bf1535f53cd6a", size = 99283, upload-time = "2025-09-06T19:30:52.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/e7/685de97986c916a6d93b3876139e00eef26ad5bbbd61925d670ae8013449/identify-2.6.15.tar.gz", hash = "sha256:e4f4864b96c6557ef2a1e1c951771838f4edc9df3a72ec7118b338801b11c7bf", size = 99311, upload-time = "2025-10-02T17:43:40.631Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/ae/2ad30f4652712c82f1c23423d79136fbce338932ad166d70c1efb86a5998/identify-2.6.14-py2.py3-none-any.whl", hash = "sha256:11a073da82212c6646b1f39bb20d4483bfb9543bd5566fec60053c4bb309bf2e", size = 99172, upload-time = "2025-09-06T19:30:51.759Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/1c/e5fd8f973d4f375adb21565739498e2e9a1e54c858a97b9a8ccfdc81da9b/identify-2.6.15-py2.py3-none-any.whl", hash = "sha256:1181ef7608e00704db228516541eb83a88a9f94433a8c80bb9b5bd54b1d81757", size = 99183, upload-time = "2025-10-02T17:43:39.137Z" },
 ]
 
 [[package]]
@@ -550,6 +663,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mutagen"
+version = "1.47.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e6/64bc71b74eef4b68e61eb921dcf72dabd9e4ec4af1e11891bbd312ccbb77/mutagen-1.47.0.tar.gz", hash = "sha256:719fadef0a978c31b4cf3c956261b3c58b6948b32023078a2117b1de09f0fc99", size = 1274186, upload-time = "2023-09-03T16:33:33.411Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/7a/620f945b96be1f6ee357d211d5bf74ab1b7fe72a9f1525aafbfe3aee6875/mutagen-1.47.0-py3-none-any.whl", hash = "sha256:edd96f50c5907a9539d8e5bba7245f62c9f520aef333d13392a79a4f70aca719", size = 194391, upload-time = "2023-09-03T16:33:29.955Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -602,8 +724,47 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "2.23"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
+]
+
+[[package]]
+name = "pycryptodomex"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/85/e24bf90972a30b0fcd16c73009add1d7d7cd9140c2498a68252028899e41/pycryptodomex-3.23.0.tar.gz", hash = "sha256:71909758f010c82bc99b0abf4ea12012c98962fbf0583c2164f8b84533c2e4da", size = 4922157, upload-time = "2025-05-17T17:23:41.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/00/10edb04777069a42490a38c137099d4b17ba6e36a4e6e28bdc7470e9e853/pycryptodomex-3.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:7b37e08e3871efe2187bc1fd9320cc81d87caf19816c648f24443483005ff886", size = 2498764, upload-time = "2025-05-17T17:22:21.453Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3f/2872a9c2d3a27eac094f9ceaa5a8a483b774ae69018040ea3240d5b11154/pycryptodomex-3.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:91979028227543010d7b2ba2471cf1d1e398b3f183cb105ac584df0c36dac28d", size = 1643012, upload-time = "2025-05-17T17:22:23.702Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/774c2e2b4f6570fbf6a4972161adbb183aeeaa1863bde31e8706f123bf92/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b8962204c47464d5c1c4038abeadd4514a133b28748bcd9fa5b6d62e3cec6fa", size = 2187643, upload-time = "2025-05-17T17:22:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a3/71065b24cb889d537954cedc3ae5466af00a2cabcff8e29b73be047e9a19/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a33986a0066860f7fcf7c7bd2bc804fa90e434183645595ae7b33d01f3c91ed8", size = 2273762, upload-time = "2025-05-17T17:22:28.313Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/0b/ff6f43b7fbef4d302c8b981fe58467b8871902cdc3eb28896b52421422cc/pycryptodomex-3.23.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7947ab8d589e3178da3d7cdeabe14f841b391e17046954f2fbcd941705762b5", size = 2313012, upload-time = "2025-05-17T17:22:30.57Z" },
+    { url = "https://files.pythonhosted.org/packages/02/de/9d4772c0506ab6da10b41159493657105d3f8bb5c53615d19452afc6b315/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c25e30a20e1b426e1f0fa00131c516f16e474204eee1139d1603e132acffc314", size = 2186856, upload-time = "2025-05-17T17:22:32.819Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ad/8b30efcd6341707a234e5eba5493700a17852ca1ac7a75daa7945fcf6427/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:da4fa650cef02db88c2b98acc5434461e027dce0ae8c22dd5a69013eaf510006", size = 2347523, upload-time = "2025-05-17T17:22:35.386Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/02/16868e9f655b7670dbb0ac4f2844145cbc42251f916fc35c414ad2359849/pycryptodomex-3.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:58b851b9effd0d072d4ca2e4542bf2a4abcf13c82a29fd2c93ce27ee2a2e9462", size = 2272825, upload-time = "2025-05-17T17:22:37.632Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/18/4ca89ac737230b52ac8ffaca42f9c6f1fd07c81a6cd821e91af79db60632/pycryptodomex-3.23.0-cp313-cp313t-win32.whl", hash = "sha256:a9d446e844f08299236780f2efa9898c818fe7e02f17263866b8550c7d5fb328", size = 1772078, upload-time = "2025-05-17T17:22:40Z" },
+    { url = "https://files.pythonhosted.org/packages/73/34/13e01c322db027682e00986873eca803f11c56ade9ba5bbf3225841ea2d4/pycryptodomex-3.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:bc65bdd9fc8de7a35a74cab1c898cab391a4add33a8fe740bda00f5976ca4708", size = 1803656, upload-time = "2025-05-17T17:22:42.139Z" },
+    { url = "https://files.pythonhosted.org/packages/54/68/9504c8796b1805d58f4425002bcca20f12880e6fa4dc2fc9a668705c7a08/pycryptodomex-3.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:c885da45e70139464f082018ac527fdaad26f1657a99ee13eecdce0f0ca24ab4", size = 1707172, upload-time = "2025-05-17T17:22:44.704Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9c/1a8f35daa39784ed8adf93a694e7e5dc15c23c741bbda06e1d45f8979e9e/pycryptodomex-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:06698f957fe1ab229a99ba2defeeae1c09af185baa909a31a5d1f9d42b1aaed6", size = 2499240, upload-time = "2025-05-17T17:22:46.953Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/62/f5221a191a97157d240cf6643747558759126c76ee92f29a3f4aee3197a5/pycryptodomex-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b2c2537863eccef2d41061e82a881dcabb04944c5c06c5aa7110b577cc487545", size = 1644042, upload-time = "2025-05-17T17:22:49.098Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/fd/5a054543c8988d4ed7b612721d7e78a4b9bf36bc3c5ad45ef45c22d0060e/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43c446e2ba8df8889e0e16f02211c25b4934898384c1ec1ec04d7889c0333587", size = 2186227, upload-time = "2025-05-17T17:22:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/a9/8862616a85cf450d2822dbd4fff1fcaba90877907a6ff5bc2672cafe42f8/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f489c4765093fb60e2edafdf223397bc716491b2b69fe74367b70d6999257a5c", size = 2272578, upload-time = "2025-05-17T17:22:53.676Z" },
+    { url = "https://files.pythonhosted.org/packages/46/9f/bda9c49a7c1842820de674ab36c79f4fbeeee03f8ff0e4f3546c3889076b/pycryptodomex-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdc69d0d3d989a1029df0eed67cc5e8e5d968f3724f4519bd03e0ec68df7543c", size = 2312166, upload-time = "2025-05-17T17:22:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/03/cc/870b9bf8ca92866ca0186534801cf8d20554ad2a76ca959538041b7a7cf4/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6bbcb1dd0f646484939e142462d9e532482bc74475cecf9c4903d4e1cd21f003", size = 2185467, upload-time = "2025-05-17T17:22:59.237Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e3/ce9348236d8e669fea5dd82a90e86be48b9c341210f44e25443162aba187/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:8a4fcd42ccb04c31268d1efeecfccfd1249612b4de6374205376b8f280321744", size = 2346104, upload-time = "2025-05-17T17:23:02.112Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/e9/e869bcee87beb89040263c416a8a50204f7f7a83ac11897646c9e71e0daf/pycryptodomex-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:55ccbe27f049743a4caf4f4221b166560d3438d0b1e5ab929e07ae1702a4d6fd", size = 2271038, upload-time = "2025-05-17T17:23:04.872Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/67/09ee8500dd22614af5fbaa51a4aee6e342b5fa8aecf0a6cb9cbf52fa6d45/pycryptodomex-3.23.0-cp37-abi3-win32.whl", hash = "sha256:189afbc87f0b9f158386bf051f720e20fa6145975f1e76369303d0f31d1a8d7c", size = 1771969, upload-time = "2025-05-17T17:23:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/69/96/11f36f71a865dd6df03716d33bd07a67e9d20f6b8d39820470b766af323c/pycryptodomex-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:52e5ca58c3a0b0bd5e100a9fbc8015059b05cffc6c66ce9d98b4b45e023443b9", size = 1803124, upload-time = "2025-05-17T17:23:09.267Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/93/45c1cdcbeb182ccd2e144c693eaa097763b08b38cded279f0053ed53c553/pycryptodomex-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:02d87b80778c171445d67e23d1caef279bf4b25c3597050ccd2e13970b57fd51", size = 1707161, upload-time = "2025-05-17T17:23:11.414Z" },
+]
+
+[[package]]
 name = "pydantic"
-version = "2.11.9"
+version = "2.11.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -611,9 +772,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/5d/09a551ba512d7ca404d785072700d3f6727a02f6f3c24ecfd081c7cf0aa8/pydantic-2.11.9.tar.gz", hash = "sha256:6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2", size = 788495, upload-time = "2025-09-13T11:26:39.325Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/54/ecab642b3bed45f7d5f59b38443dcb36ef50f85af192e6ece103dbfe9587/pydantic-2.11.10.tar.gz", hash = "sha256:dc280f0982fbda6c38fada4e476dc0a4f3aeaf9c6ad4c28df68a666ec3c61423", size = 788494, upload-time = "2025-10-04T10:40:41.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/d3/108f2006987c58e76691d5ae5d200dd3e0f532cb4e5fa3560751c3a1feba/pydantic-2.11.9-py3-none-any.whl", hash = "sha256:c42dd626f5cfc1c6950ce6205ea58c93efa406da65f479dcb4029d5934857da2", size = 444855, upload-time = "2025-09-13T11:26:36.909Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl", hash = "sha256:802a655709d49bd004c31e865ef37da30b540786a46bfce02333e0e24b5fe29a", size = 444823, upload-time = "2025-10-04T10:40:39.055Z" },
 ]
 
 [[package]]
@@ -835,6 +996,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
 name = "respx"
 version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
@@ -848,28 +1024,28 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.13.2"
+version = "0.13.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/02/df/8d7d8c515d33adfc540e2edf6c6021ea1c5a58a678d8cfce9fae59aabcab/ruff-0.13.2.tar.gz", hash = "sha256:cb12fffd32fb16d32cef4ed16d8c7cdc27ed7c944eaa98d99d01ab7ab0b710ff", size = 5416417, upload-time = "2025-09-25T14:54:09.936Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/8e/f9f9ca747fea8e3ac954e3690d4698c9737c23b51731d02df999c150b1c9/ruff-0.13.3.tar.gz", hash = "sha256:5b0ba0db740eefdfbcce4299f49e9eaefc643d4d007749d77d047c2bab19908e", size = 5438533, upload-time = "2025-10-02T19:29:31.582Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/84/5716a7fa4758e41bf70e603e13637c42cfb9dbf7ceb07180211b9bbf75ef/ruff-0.13.2-py3-none-linux_armv6l.whl", hash = "sha256:3796345842b55f033a78285e4f1641078f902020d8450cade03aad01bffd81c3", size = 12343254, upload-time = "2025-09-25T14:53:27.784Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/77/c7042582401bb9ac8eff25360e9335e901d7a1c0749a2b28ba4ecb239991/ruff-0.13.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ff7e4dda12e683e9709ac89e2dd436abf31a4d8a8fc3d89656231ed808e231d2", size = 13040891, upload-time = "2025-09-25T14:53:31.38Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/15/125a7f76eb295cb34d19c6778e3a82ace33730ad4e6f28d3427e134a02e0/ruff-0.13.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c75e9d2a2fafd1fdd895d0e7e24b44355984affdde1c412a6f6d3f6e16b22d46", size = 12243588, upload-time = "2025-09-25T14:53:33.543Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/eb/0093ae04a70f81f8be7fd7ed6456e926b65d238fc122311293d033fdf91e/ruff-0.13.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cceac74e7bbc53ed7d15d1042ffe7b6577bf294611ad90393bf9b2a0f0ec7cb6", size = 12491359, upload-time = "2025-09-25T14:53:35.892Z" },
-    { url = "https://files.pythonhosted.org/packages/43/fe/72b525948a6956f07dad4a6f122336b6a05f2e3fd27471cea612349fedb9/ruff-0.13.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6ae3f469b5465ba6d9721383ae9d49310c19b452a161b57507764d7ef15f4b07", size = 12162486, upload-time = "2025-09-25T14:53:38.171Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/e3/0fac422bbbfb2ea838023e0d9fcf1f30183d83ab2482800e2cb892d02dfe/ruff-0.13.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4f8f9e3cd6714358238cd6626b9d43026ed19c0c018376ac1ef3c3a04ffb42d8", size = 13871203, upload-time = "2025-09-25T14:53:41.943Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/82/b721c8e3ec5df6d83ba0e45dcf00892c4f98b325256c42c38ef136496cbf/ruff-0.13.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:c6ed79584a8f6cbe2e5d7dbacf7cc1ee29cbdb5df1172e77fbdadc8bb85a1f89", size = 14929635, upload-time = "2025-09-25T14:53:43.953Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/a0/ad56faf6daa507b83079a1ad7a11694b87d61e6bf01c66bd82b466f21821/ruff-0.13.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aed130b2fde049cea2019f55deb939103123cdd191105f97a0599a3e753d61b0", size = 14338783, upload-time = "2025-09-25T14:53:46.205Z" },
-    { url = "https://files.pythonhosted.org/packages/47/77/ad1d9156db8f99cd01ee7e29d74b34050e8075a8438e589121fcd25c4b08/ruff-0.13.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1887c230c2c9d65ed1b4e4cfe4d255577ea28b718ae226c348ae68df958191aa", size = 13355322, upload-time = "2025-09-25T14:53:48.164Z" },
-    { url = "https://files.pythonhosted.org/packages/64/8b/e87cfca2be6f8b9f41f0bb12dc48c6455e2d66df46fe61bb441a226f1089/ruff-0.13.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5bcb10276b69b3cfea3a102ca119ffe5c6ba3901e20e60cf9efb53fa417633c3", size = 13354427, upload-time = "2025-09-25T14:53:50.486Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/df/bf382f3fbead082a575edb860897287f42b1b3c694bafa16bc9904c11ed3/ruff-0.13.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:afa721017aa55a555b2ff7944816587f1cb813c2c0a882d158f59b832da1660d", size = 13537637, upload-time = "2025-09-25T14:53:52.887Z" },
-    { url = "https://files.pythonhosted.org/packages/51/70/1fb7a7c8a6fc8bd15636288a46e209e81913b87988f26e1913d0851e54f4/ruff-0.13.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1dbc875cf3720c64b3990fef8939334e74cb0ca65b8dbc61d1f439201a38101b", size = 12340025, upload-time = "2025-09-25T14:53:54.88Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/27/1e5b3f1c23ca5dd4106d9d580e5c13d9acb70288bff614b3d7b638378cc9/ruff-0.13.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5b939a1b2a960e9742e9a347e5bbc9b3c3d2c716f86c6ae273d9cbd64f193f22", size = 12133449, upload-time = "2025-09-25T14:53:57.089Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/09/b92a5ccee289f11ab128df57d5911224197d8d55ef3bd2043534ff72ca54/ruff-0.13.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:50e2d52acb8de3804fc5f6e2fa3ae9bdc6812410a9e46837e673ad1f90a18736", size = 13051369, upload-time = "2025-09-25T14:53:59.124Z" },
-    { url = "https://files.pythonhosted.org/packages/89/99/26c9d1c7d8150f45e346dc045cc49f23e961efceb4a70c47dea0960dea9a/ruff-0.13.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3196bc13ab2110c176b9a4ae5ff7ab676faaa1964b330a1383ba20e1e19645f2", size = 13523644, upload-time = "2025-09-25T14:54:01.622Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/00/e7f1501e81e8ec290e79527827af1d88f541d8d26151751b46108978dade/ruff-0.13.2-py3-none-win32.whl", hash = "sha256:7c2a0b7c1e87795fec3404a485096bcd790216c7c146a922d121d8b9c8f1aaac", size = 12245990, upload-time = "2025-09-25T14:54:03.647Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/bd/d9f33a73de84fafd0146c6fba4f497c4565fe8fa8b46874b8e438869abc2/ruff-0.13.2-py3-none-win_amd64.whl", hash = "sha256:17d95fb32218357c89355f6f6f9a804133e404fc1f65694372e02a557edf8585", size = 13324004, upload-time = "2025-09-25T14:54:06.05Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/12/28fa2f597a605884deb0f65c1b1ae05111051b2a7030f5d8a4ff7f4599ba/ruff-0.13.2-py3-none-win_arm64.whl", hash = "sha256:da711b14c530412c827219312b7d7fbb4877fb31150083add7e8c5336549cea7", size = 12484437, upload-time = "2025-09-25T14:54:08.022Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/33/8f7163553481466a92656d35dea9331095122bb84cf98210bef597dd2ecd/ruff-0.13.3-py3-none-linux_armv6l.whl", hash = "sha256:311860a4c5e19189c89d035638f500c1e191d283d0cc2f1600c8c80d6dcd430c", size = 12484040, upload-time = "2025-10-02T19:28:49.199Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b5/4a21a4922e5dd6845e91896b0d9ef493574cbe061ef7d00a73c61db531af/ruff-0.13.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:2bdad6512fb666b40fcadb65e33add2b040fc18a24997d2e47fee7d66f7fcae2", size = 13122975, upload-time = "2025-10-02T19:28:52.446Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/15649af836d88c9f154e5be87e64ae7d2b1baa5a3ef317cb0c8fafcd882d/ruff-0.13.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fc6fa4637284708d6ed4e5e970d52fc3b76a557d7b4e85a53013d9d201d93286", size = 12346621, upload-time = "2025-10-02T19:28:54.712Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/bcbccb8141305f9a6d3f72549dd82d1134299177cc7eaf832599700f95a7/ruff-0.13.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c9e6469864f94a98f412f20ea143d547e4c652f45e44f369d7b74ee78185838", size = 12574408, upload-time = "2025-10-02T19:28:56.679Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/19/0f3681c941cdcfa2d110ce4515624c07a964dc315d3100d889fcad3bfc9e/ruff-0.13.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5bf62b705f319476c78891e0e97e965b21db468b3c999086de8ffb0d40fd2822", size = 12285330, upload-time = "2025-10-02T19:28:58.79Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f8/387976bf00d126b907bbd7725219257feea58650e6b055b29b224d8cb731/ruff-0.13.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:78cc1abed87ce40cb07ee0667ce99dbc766c9f519eabfd948ed87295d8737c60", size = 13980815, upload-time = "2025-10-02T19:29:01.577Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a6/7c8ec09d62d5a406e2b17d159e4817b63c945a8b9188a771193b7e1cc0b5/ruff-0.13.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:4fb75e7c402d504f7a9a259e0442b96403fa4a7310ffe3588d11d7e170d2b1e3", size = 14987733, upload-time = "2025-10-02T19:29:04.036Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e5/f403a60a12258e0fd0c2195341cfa170726f254c788673495d86ab5a9a9d/ruff-0.13.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:17b951f9d9afb39330b2bdd2dd144ce1c1335881c277837ac1b50bfd99985ed3", size = 14439848, upload-time = "2025-10-02T19:29:06.684Z" },
+    { url = "https://files.pythonhosted.org/packages/39/49/3de381343e89364c2334c9f3268b0349dc734fc18b2d99a302d0935c8345/ruff-0.13.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6052f8088728898e0a449f0dde8fafc7ed47e4d878168b211977e3e7e854f662", size = 13421890, upload-time = "2025-10-02T19:29:08.767Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b5/c0feca27d45ae74185a6bacc399f5d8920ab82df2d732a17213fb86a2c4c/ruff-0.13.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc742c50f4ba72ce2a3be362bd359aef7d0d302bf7637a6f942eaa763bd292af", size = 13444870, upload-time = "2025-10-02T19:29:11.234Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a1/b655298a1f3fda4fdc7340c3f671a4b260b009068fbeb3e4e151e9e3e1bf/ruff-0.13.3-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:8e5640349493b378431637019366bbd73c927e515c9c1babfea3e932f5e68e1d", size = 13691599, upload-time = "2025-10-02T19:29:13.353Z" },
+    { url = "https://files.pythonhosted.org/packages/32/b0/a8705065b2dafae007bcae21354e6e2e832e03eb077bb6c8e523c2becb92/ruff-0.13.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6b139f638a80eae7073c691a5dd8d581e0ba319540be97c343d60fb12949c8d0", size = 12421893, upload-time = "2025-10-02T19:29:15.668Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/1e/cbe7082588d025cddbb2f23e6dfef08b1a2ef6d6f8328584ad3015b5cebd/ruff-0.13.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:6b547def0a40054825de7cfa341039ebdfa51f3d4bfa6a0772940ed351d2746c", size = 12267220, upload-time = "2025-10-02T19:29:17.583Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/99/4086f9c43f85e0755996d09bdcb334b6fee9b1eabdf34e7d8b877fadf964/ruff-0.13.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9cc48a3564423915c93573f1981d57d101e617839bef38504f85f3677b3a0a3e", size = 13177818, upload-time = "2025-10-02T19:29:19.943Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/de/7b5db7e39947d9dc1c5f9f17b838ad6e680527d45288eeb568e860467010/ruff-0.13.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1a993b17ec03719c502881cb2d5f91771e8742f2ca6de740034433a97c561989", size = 13618715, upload-time = "2025-10-02T19:29:22.527Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d3/bb25ee567ce2f61ac52430cf99f446b0e6d49bdfa4188699ad005fdd16aa/ruff-0.13.3-py3-none-win32.whl", hash = "sha256:f14e0d1fe6460f07814d03c6e32e815bff411505178a1f539a38f6097d3e8ee3", size = 12334488, upload-time = "2025-10-02T19:29:24.782Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/49/12f5955818a1139eed288753479ba9d996f6ea0b101784bb1fe6977ec128/ruff-0.13.3-py3-none-win_amd64.whl", hash = "sha256:621e2e5812b691d4f244638d693e640f188bacbb9bc793ddd46837cea0503dd2", size = 13455262, upload-time = "2025-10-02T19:29:26.882Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/72/7b83242b26627a00e3af70d0394d68f8f02750d642567af12983031777fc/ruff-0.13.3-py3-none-win_arm64.whl", hash = "sha256:9e9e9d699841eaf4c2c798fa783df2fabc680b72059a02ca0ed81c460bc58330", size = 12538484, upload-time = "2025-10-02T19:29:28.951Z" },
 ]
 
 [[package]]
@@ -1019,6 +1195,15 @@ wheels = [
 ]
 
 [[package]]
+name = "urllib3"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
 name = "uvicorn"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1151,4 +1336,16 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/8f/0daea0feec1ab85e7df85b98ec7cc8c85d706362e80efc5375c7007dc3dc/yt_dlp-2025.9.26.tar.gz", hash = "sha256:c148ae8233ac4ce6c5fbf6f70fcc390f13a00f59da3776d373cf88c5370bda86", size = 3037475, upload-time = "2025-09-26T22:23:42.882Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/94/18210c5e6a9d7e622a3b3f4a73dde205f7adf0c46b42b27d0da8c6e5c872/yt_dlp-2025.9.26-py3-none-any.whl", hash = "sha256:36f5fbc153600f759abd48d257231f0e0a547a115ac7ffb05d5b64e5c7fdf8a2", size = 3241906, upload-time = "2025-09-26T22:23:39.976Z" },
+]
+
+[package.optional-dependencies]
+default = [
+    { name = "brotli", marker = "implementation_name == 'cpython'" },
+    { name = "brotlicffi", marker = "implementation_name != 'cpython'" },
+    { name = "certifi" },
+    { name = "mutagen" },
+    { name = "pycryptodomex" },
+    { name = "requests" },
+    { name = "urllib3" },
+    { name = "websockets" },
 ]


### PR DESCRIPTION
# Add Patreon Source Support with Handler-Based Architecture

## Summary

This PR adds first-class support for Patreon sources alongside YouTube, enabling users to subscribe to Patreon creator pages and individual posts as RSS podcast feeds. This fills in the handler-based architecture for multi-source support and includes new media processing utilities.

**Key features:**
- Patreon creator pages and individual posts now supported as feed sources
- Video-only filtering by default (audio-only posts excluded, to be added as an option later)
- Handler-based architecture enables future source additions
- FFmpeg/FFprobe wrappers for better separation of concerns and composability

## Changes

### Core Functionality

**Patreon Handler** ([src/anypod/ytdlp_wrapper/patreon_handler.py](src/anypod/ytdlp_wrapper/patreon_handler.py))
- Implements `SourceHandlerBase` protocol for Patreon sources
- Maps Patreon creator pages to `SourceType.PLAYLIST`, individual posts to `SourceType.SINGLE_VIDEO`
- Applies required Patreon-specific headers (referer) and video-only filtering
- Handles Patreon-specific metadata quirks (missing duration, optional thumbnails)
- Graceful handling of inaccessible tier-restricted posts

**Handler Selection Architecture** ([src/anypod/ytdlp_wrapper/base_handler.py](src/anypod/ytdlp_wrapper/base_handler.py))
- New `HandlerSelector` class routes URLs to appropriate handlers by hostname
- Refactored `YoutubeHandler` to work within handler framework
- Updated `YtdlpWrapper` to use dynamic handler selection

**yt-dlp Args Enhancements** ([src/anypod/ytdlp_wrapper/core/args.py](src/anypod/ytdlp_wrapper/core/args.py))
- Added `referer(url: str)` method for custom HTTP referer headers
- Added `match_filter(expr: str)` method for content filtering

### Media Processing

**FFProbe Wrapper** ([src/anypod/ffprobe.py](src/anypod/ffprobe.py))
- Detects image formats for conversion decisions
- Extracts media duration as fallback when yt-dlp metadata incomplete
- Async subprocess invocation with structured error handling

**FFmpeg Wrapper** ([src/anypod/ffmpeg.py](src/anypod/ffmpeg.py))
- Converts images to JPG/MJPEG format for consistent podcast artwork
- Replaces inline subprocess calls in `ImageDownloader`

### Documentation

- [README.md](README.md): Added Patreon beta section with cookies requirement and video-only note
- [DESIGN_DOC.md](DESIGN_DOC.md): Updated system dependencies (ffmpeg/ffprobe)
- [docs/designs/05-patreon-handler.md](docs/designs/05-patreon-handler.md): Complete design document for Patreon support
- [.claude/commands/prd.md](.claude/commands/prd.md): New PRD workflow command for future features

### Configuration

- Updated `pyproject.toml` dev dependency: `yt-dlp[default]` for [future Deno requirement](https://github.com/yt-dlp/yt-dlp/issues/14404)

### Testing

**Unit Tests**
- [tests/anypod/test_ffprobe.py](tests/anypod/test_ffprobe.py): FFProbe wrapper tests
- [tests/anypod/test_ffmpeg.py](tests/anypod/test_ffmpeg.py): FFmpeg wrapper tests
- [tests/anypod/ytdlp_wrapper/test_patreon_handler.py](tests/anypod/ytdlp_wrapper/test_patreon_handler.py): Comprehensive Patreon handler tests
- Updated wrapper and handler tests for new architecture

**Integration Tests**
- [tests/integration/test_integration_ff.py](tests/integration/test_integration_ff.py): FFmpeg/FFprobe integration tests
- Updated image downloader integration tests

## Operational Notes

### Patreon Requirements

1. **Cookies Required**: Patreon content typically requires authentication. Mount a `cookies.txt` file at `/cookies/cookies.txt` with an authenticated Patreon session.

2. **Video-Only Default**: Audio-only Patreon posts are filtered out by default using `--match-filter vcodec`. Future releases may add configuration to include audio.

3. **Beta Status**: Limited testing across creator tiers; edge cases may exist.

### Example Configuration

```yaml
feeds:
  my_patreon_feed:
    url: https://www.patreon.com/CreatorName
    schedule: "0 6 * * *"
    keep_last: 10
    metadata:
      title: "My Patreon Feed"
      explicit: "no"
```

## Breaking Changes

None. Existing YouTube feeds are unaffected.

## Migration Guide

No migration required. Add Patreon URLs to `feeds.yaml` alongside existing YouTube feeds.

## Testing Checklist

- [x] All existing unit tests pass
- [x] New Patreon handler unit tests added
- [x] FFmpeg/FFprobe wrapper tests added
- [x] Handler selection tests verify correct dispatch
- [x] YouTube handler refactoring maintains backward compatibility
- [x] Integration tests updated for new architecture

## Follow-up Work

- [ ] Audio-only Patreon posts: add opt-in config to include audio
- [ ] Tier-based filtering for inaccessible posts (if possible)
- [ ] Centralize shared entry parsing across handlers
- [ ] Convert back to using yt-dlp as Python package (currently uses CLI, need to make change for upcoming Deno req)