### PR TITLE
feat(api): add single-server mode for unified HTTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,14 +198,15 @@ For full configuration details including manual feeds, metadata overrides, and r
 
 All can be provided via env or CLI flags (kebab‑case). Common ones:
 
-| Name                | Default                            | Description                                                 |
-| ------------------- | ---------------------------------- | ----------------------------------------------------------- |
-| `BASE_URL`          | `http://reverseproxy.example:8024` | Public base URL for feed/media links                        |
-| `SERVER_PORT`       | `8024`                             | Bind port for public server                                 |
-| `ADMIN_SERVER_PORT` | `8025`                             | Bind port for admin server (should not be exposed publicly) |
-| `TRUSTED_PROXIES`   | unset                              | Trusted proxy IPs/networks (e.g. `["192.168.1.0/24"]`)      |
-| `POT_PROVIDER_URL`  | unset                              | bgutil POT provider URL for YouTube PO Tokens               |
-| `PUID` / `PGID`     | `1000`                             | Container user/group                                        |
+| Name                 | Default                            | Description                                                       |
+| -------------------- | ---------------------------------- | ----------------------------------------------------------------- |
+| `BASE_URL`           | `http://reverseproxy.example:8024` | Public base URL for feed/media links                              |
+| `SERVER_PORT`        | `8024`                             | Bind port for public server                                       |
+| `ADMIN_SERVER_PORT`  | `8025`                             | Bind port for admin server (should not be exposed publicly)       |
+| `SINGLE_SERVER_MODE` | `false`                            | Mount admin routes on main server (requires external path gating) |
+| `TRUSTED_PROXIES`    | unset                              | Trusted proxy IPs/networks (e.g. `["192.168.1.0/24"]`)            |
+| `POT_PROVIDER_URL`   | unset                              | bgutil POT provider URL for YouTube PO Tokens                     |
+| `PUID` / `PGID`      | `1000`                             | Container user/group                                              |
 
 For the complete list of environment variables, see [docs/configuration.md](docs/configuration.md#environment-variables).
 
@@ -233,7 +234,9 @@ For the complete list of environment variables, see [docs/configuration.md](docs
 - `DELETE /admin/feeds/{feed_id}/downloads/{download_id}` – delete a download from a manual feed and clean up associated media files and thumbnails; regenerates RSS
 - `GET /api/health` – health check
 
-Admin endpoints run on a separate server. No authentication is implemented. Only expose the public server publicly.
+Admin endpoints run on a separate server by default. No authentication is implemented. Only expose the public server publicly.
+
+When `SINGLE_SERVER_MODE=true`, admin routes are mounted on the main server under `/admin/`. Use this only when external access control (e.g., Cloudflare Access, Nginx auth) protects admin paths. See [docs/configuration.md](docs/configuration.md#single-server-mode) for details.
 
 ## Reverse proxies
 

--- a/src/anypod/config/config.py
+++ b/src/anypod/config/config.py
@@ -232,6 +232,15 @@ class AppSettings(BaseSettings):
         validation_alias="ADMIN_SERVER_PORT",
         description="Port number for the admin HTTP server (default: 8025). Should not be exposed to the public.",
     )
+    single_server_mode: bool = Field(
+        default=False,
+        validation_alias="SINGLE_SERVER_MODE",
+        description=(
+            "When enabled, mounts admin routes on the main server under /admin/ instead of running "
+            "a separate admin server. Use only when admin access is protected at the infrastructure level "
+            "(e.g., Cloudflare Access). WARNING: Admin APIs will be exposed on the public port."
+        ),
+    )
     trusted_proxies: list[str] | None = Field(
         default=None,
         validation_alias="TRUSTED_PROXIES",

--- a/src/anypod/server/app.py
+++ b/src/anypod/server/app.py
@@ -110,6 +110,7 @@ def create_app(
     manual_submission_service: ManualSubmissionService,
     cookies_path: Path | None = None,
     shutdown_callback: Callable[[], Awaitable[None]] | None = None,
+    include_admin: bool = False,
 ) -> FastAPI:
     """Create and configure a FastAPI application instance.
 
@@ -127,6 +128,7 @@ def create_app(
         manual_submission_service: Service for manual submission metadata fetches.
         cookies_path: Path to cookies.txt file for authentication.
         shutdown_callback: Optional callback function for graceful shutdown.
+        include_admin: When true, mount admin routes on this app (single-server mode).
 
     Returns:
         Configured FastAPI application instance.
@@ -178,6 +180,10 @@ def create_app(
     # Include public routers
     app.include_router(static.router, tags=["static"])
     app.include_router(health.router, tags=["health"])  # /api/health on public server
+
+    # Include admin router in single-server mode
+    if include_admin:
+        app.include_router(admin.router, tags=["admin"])
 
     logger.debug("FastAPI application created successfully")
 

--- a/src/anypod/server/server.py
+++ b/src/anypod/server/server.py
@@ -36,6 +36,7 @@ def create_server(
     feed_configs: dict[str, FeedConfig],
     cookies_path: Path | None,
     shutdown_callback: Callable[[], Awaitable[None]] | None = None,
+    include_admin: bool = False,
 ) -> uvicorn.Server:
     """Create and configure a uvicorn HTTP server with FastAPI app.
 
@@ -51,6 +52,7 @@ def create_server(
         feed_configs: The feed configurations.
         cookies_path: Path to cookies.txt file for authentication.
         shutdown_callback: Optional callback to execute during shutdown.
+        include_admin: When true, mount admin routes on the main app (single-server mode).
 
     Returns:
         Configured uvicorn server ready to run.
@@ -67,6 +69,7 @@ def create_server(
         manual_submission_service=manual_submission_service,
         cookies_path=cookies_path,
         shutdown_callback=shutdown_callback,
+        include_admin=include_admin,
     )
 
     # Configure proxy settings based on trusted_proxies


### PR DESCRIPTION
Add SINGLE_SERVER_MODE configuration option that mounts admin routes on the
main HTTP server under /admin/ instead of running a separate admin server.
This simplifies deployment when admin access is protected at the infrastructure
level (e.g., Cloudflare Access, Nginx auth).

When enabled:
- Admin router mounted on main app with /admin prefix
- Security warning logged at startup
- ADMIN_SERVER_PORT configuration ignored
- Only one server runs in asyncio gather

Default behavior (dual-server mode) unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded configuration documentation with new Single-Server Mode section including security considerations and deployment guidance.

* **New Features**
  * Single-Server Mode: Admin routes now available on the main server under /admin/ instead of running as a separate server, simplifying deployments with infrastructure-level access control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->