### PR TITLE
fix: treat NOT_AVAILABLE transcript as not-applicable instead of failure

### DIFF
--- a/src/anypod/data_coordinator/downloader.py
+++ b/src/anypod/data_coordinator/downloader.py
@@ -541,7 +541,11 @@ class Downloader:
             logger.debug("Media artifact downloaded successfully.", extra=log_params)
 
             thumbnail_downloaded = download.thumbnail_ext is not None
-            if feed_config.transcript_lang is None:
+            if (
+                feed_config.transcript_lang is None
+                or download.transcript_source
+                not in [TranscriptSource.CREATOR, TranscriptSource.AUTO]
+            ):
                 transcript_downloaded = None
             else:
                 transcript_downloaded = downloaded_media.transcript is not None

--- a/tests/anypod/data_coordinator/test_downloader.py
+++ b/tests/anypod/data_coordinator/test_downloader.py
@@ -332,6 +332,47 @@ async def test_download_artifacts_all_success_flow(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "transcript_source",
+    [TranscriptSource.NOT_AVAILABLE, None],
+)
+@patch.object(Downloader, "_handle_download_success", new_callable=AsyncMock)
+async def test_download_artifacts_all_transcript_not_applicable_is_none(
+    mock_handle_success: AsyncMock,
+    downloader: Downloader,
+    mock_ytdlp_wrapper: MagicMock,
+    sample_download: Download,
+    sample_feed_config: FeedConfig,
+    transcript_source: TranscriptSource | None,
+):
+    """Returns None for transcript_downloaded when transcript is not applicable."""
+    sample_download.transcript_source = transcript_source
+    sample_feed_config.transcript_lang = "en"
+
+    downloaded_path = Path("/final/video.mp4")
+    mock_ytdlp_wrapper.download_media_to_file.return_value = DownloadedMedia(
+        file_path=downloaded_path,
+        logs="ok",
+        transcript=None,
+    )
+
+    def set_thumbnail_ext(*_args: object, **_kwargs: object) -> None:
+        sample_download.thumbnail_ext = "jpg"
+
+    mock_handle_success.side_effect = set_thumbnail_ext
+
+    result = await downloader.download_artifacts(
+        sample_download, sample_feed_config, DownloadArtifact.ALL
+    )
+
+    assert result.media_downloaded is True
+    assert result.thumbnail_downloaded is True
+    assert result.transcript_downloaded is None
+    assert result.all_succeeded is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_download_artifacts_all_ytdlp_failure_returns_failure(
     downloader: Downloader,
     mock_ytdlp_wrapper: MagicMock,


### PR DESCRIPTION
## Problem

When a download has `transcript_source=NOT_AVAILABLE` (e.g., Twitter videos that don't have subtitles), the media download correctly skips transcript retrieval. However, `download_artifacts` still reported `transcript_downloaded=False`, causing `all_succeeded` to return `False` and `download_queued` to treat the entire download as a failure.

This resulted in `_handle_download_failure` running after `_handle_download_success` had already succeeded, bumping the retry count and logging a spurious `DownloadError: Unknown error`.

**Observed in logs:**
```
INFO  Successfully downloaded media.  download_id=2031844895573622787
ERROR Could not complete download.    exc_info=DownloadError: Unknown error  download_id=2031844895573622787
```

The download ended up with `status=DOWNLOADED` but `retries=1` and `last_error="Unknown error"`.

## Fix

In the MEDIA branch of `download_artifacts`, check `transcript_source` alongside `transcript_lang` when determining the `transcript_downloaded` result. `NOT_AVAILABLE` now yields `None` (not applicable) instead of `False` (failed).

## Test

Added test case `test_download_artifacts_all_transcript_not_available_is_none` that verifies:
- Media downloads successfully
- Thumbnail downloads successfully  
- `transcript_downloaded` is `None` (not `False`)
- `all_succeeded` is `True`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript handling during media downloads: transcripts are now marked not applicable (None) when either no transcript language is configured or the transcript source is not permitted, providing more accurate availability and status reporting.

* **Tests**
  * Added a unit test covering the “transcript not applicable” scenario to ensure correct download outcomes and status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->