### PR TITLE
fix: fail feed sync on yt-dlp network errors

### DIFF
--- a/src/anypod/ytdlp_wrapper/core/core.py
+++ b/src/anypod/ytdlp_wrapper/core/core.py
@@ -22,27 +22,25 @@ def _format_run_output(stdout: str, stderr: str) -> str:
     return "\n\n".join(sections)
 
 
-_NETWORK_ERROR_MARKERS = (
-    "temporary failure in name resolution",
-    "name or service not known",
-    "failed to resolve",
-    "could not resolve",
-    "network is unreachable",
-    "no route to host",
-    "connection timed out",
-    "timed out",
-    "connection reset by peer",
-    "connection refused",
-    "remote end closed connection",
-    "ssl: certificate_verify_failed",
-    "tlsv1 alert",
-)
+_DNS_RESOLUTION_ERROR_MARKERS = ("[Errno -3] Temporary failure in name resolution",)
 
 
-def _looks_like_network_error(stderr: str) -> bool:
-    """Return true for yt-dlp failures that indicate an unreliable network fetch."""
-    normalized = stderr.lower()
-    return any(marker in normalized for marker in _NETWORK_ERROR_MARKERS)
+def _looks_like_dns_resolution_error(stderr: str) -> bool:
+    """Return true for yt-dlp DNS-resolution failures.
+
+    This intentionally matches the concrete socket.gaierror text observed from
+    yt-dlp when YouTube metadata extraction cannot resolve a hostname. Other
+    non-network yt-dlp errors are left as non-fatal so playlist processing can
+    continue to tolerate private, deleted, filtered, or otherwise unavailable
+    entries.
+
+    Args:
+        stderr: The raw stderr text from the yt-dlp subprocess.
+
+    Returns:
+        True if stderr contains a known DNS-resolution marker; otherwise False.
+    """
+    return any(marker in stderr for marker in _DNS_RESOLUTION_ERROR_MARKERS)
 
 
 @dataclass(frozen=True, slots=True)
@@ -234,11 +232,11 @@ class YtdlpCore:
                                 "exit_code": proc.returncode,
                             },
                         )
-            if _looks_like_network_error(stderr_text):
+            if _looks_like_dns_resolution_error(stderr_text):
                 raise YtdlpApiError(
                     message=(
                         "yt-dlp downloads metadata extraction failed due to a "
-                        "network error."
+                        "DNS resolution error."
                     ),
                     url=url,
                     logs=combined_logs,

--- a/src/anypod/ytdlp_wrapper/core/core.py
+++ b/src/anypod/ytdlp_wrapper/core/core.py
@@ -22,6 +22,29 @@ def _format_run_output(stdout: str, stderr: str) -> str:
     return "\n\n".join(sections)
 
 
+_NETWORK_ERROR_MARKERS = (
+    "temporary failure in name resolution",
+    "name or service not known",
+    "failed to resolve",
+    "could not resolve",
+    "network is unreachable",
+    "no route to host",
+    "connection timed out",
+    "timed out",
+    "connection reset by peer",
+    "connection refused",
+    "remote end closed connection",
+    "ssl: certificate_verify_failed",
+    "tlsv1 alert",
+)
+
+
+def _looks_like_network_error(stderr: str) -> bool:
+    """Return true for yt-dlp failures that indicate an unreliable network fetch."""
+    normalized = stderr.lower()
+    return any(marker in normalized for marker in _NETWORK_ERROR_MARKERS)
+
+
 @dataclass(frozen=True, slots=True)
 class YtdlpRunResult[T]:
     """Container for yt-dlp subprocess payloads and raw log output."""
@@ -211,6 +234,15 @@ class YtdlpCore:
                                 "exit_code": proc.returncode,
                             },
                         )
+            if _looks_like_network_error(stderr_text):
+                raise YtdlpApiError(
+                    message=(
+                        "yt-dlp downloads metadata extraction failed due to a "
+                        "network error."
+                    ),
+                    url=url,
+                    logs=combined_logs,
+                )
             if not entries and proc.returncode != 101:  # 101 == filtered out
                 logger.warning(
                     "yt-dlp completed with errors and extracted no entries.",

--- a/tests/anypod/ytdlp_wrapper/test_ytdlp_core.py
+++ b/tests/anypod/ytdlp_wrapper/test_ytdlp_core.py
@@ -1,0 +1,55 @@
+"""Tests for low-level yt-dlp subprocess handling."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from anypod.exceptions import YtdlpApiError
+from anypod.ytdlp_wrapper.core import YtdlpArgs, YtdlpCore
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec", new_callable=AsyncMock)
+async def test_extract_downloads_info_raises_on_network_error(
+    mock_create_subprocess_exec: AsyncMock,
+):
+    """Network failures make playlist metadata unreliable and should fail the sync."""
+    mock_proc = MagicMock()
+    mock_proc.returncode = 1
+    mock_proc.communicate = AsyncMock(
+        return_value=(
+            b"",
+            b"ERROR: Unable to download webpage: <urlopen error "
+            b"[Errno -3] Temporary failure in name resolution>",
+        )
+    )
+    mock_proc.wait = AsyncMock()
+    mock_create_subprocess_exec.return_value = mock_proc
+
+    with pytest.raises(YtdlpApiError, match="network error"):
+        await YtdlpCore.extract_downloads_info(
+            YtdlpArgs(), "https://youtube.com/playlist?list=test"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec", new_callable=AsyncMock)
+async def test_extract_downloads_info_ignores_non_network_ytdlp_errors(
+    mock_create_subprocess_exec: AsyncMock,
+):
+    """Non-network yt-dlp errors remain ignored for partial/filtered playlist cases."""
+    mock_proc = MagicMock()
+    mock_proc.returncode = 101
+    mock_proc.communicate = AsyncMock(
+        return_value=(b"", b"ERROR: [youtube] abc123: Video unavailable. This video is private")
+    )
+    mock_proc.wait = AsyncMock()
+    mock_create_subprocess_exec.return_value = mock_proc
+
+    result = await YtdlpCore.extract_downloads_info(
+        YtdlpArgs(), "https://youtube.com/playlist?list=test"
+    )
+
+    assert result.payload == []

--- a/tests/anypod/ytdlp_wrapper/test_ytdlp_core.py
+++ b/tests/anypod/ytdlp_wrapper/test_ytdlp_core.py
@@ -1,3 +1,4 @@
+# pyright: reportPrivateUsage=false
 """Tests for low-level yt-dlp subprocess handling."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -11,10 +12,10 @@ from anypod.ytdlp_wrapper.core import YtdlpArgs, YtdlpCore
 @pytest.mark.unit
 @pytest.mark.asyncio
 @patch("asyncio.create_subprocess_exec", new_callable=AsyncMock)
-async def test_extract_downloads_info_raises_on_network_error(
+async def test_extract_downloads_info_raises_on_dns_resolution_error(
     mock_create_subprocess_exec: AsyncMock,
 ):
-    """Network failures make playlist metadata unreliable and should fail the sync."""
+    """DNS failures make playlist metadata unreliable and should fail the sync."""
     mock_proc = MagicMock()
     mock_proc.returncode = 1
     mock_proc.communicate = AsyncMock(
@@ -27,7 +28,7 @@ async def test_extract_downloads_info_raises_on_network_error(
     mock_proc.wait = AsyncMock()
     mock_create_subprocess_exec.return_value = mock_proc
 
-    with pytest.raises(YtdlpApiError, match="network error"):
+    with pytest.raises(YtdlpApiError):
         await YtdlpCore.extract_downloads_info(
             YtdlpArgs(), "https://youtube.com/playlist?list=test"
         )
@@ -54,5 +55,25 @@ async def test_extract_downloads_info_ignores_non_network_ytdlp_errors(
     result = await YtdlpCore.extract_downloads_info(
         YtdlpArgs(), "https://youtube.com/playlist?list=test"
     )
+
+    assert result.payload == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@patch("asyncio.create_subprocess_exec", new_callable=AsyncMock)
+async def test_extract_downloads_info_ignores_generic_non_network_ytdlp_errors(
+    mock_create_subprocess_exec: AsyncMock,
+):
+    """Generic non-network yt-dlp errors return an empty payload without raising."""
+    mock_proc = MagicMock()
+    mock_proc.returncode = 1
+    mock_proc.communicate = AsyncMock(
+        return_value=(b"", b"ERROR: Unsupported URL: https://example.com")
+    )
+    mock_proc.wait = AsyncMock()
+    mock_create_subprocess_exec.return_value = mock_proc
+
+    result = await YtdlpCore.extract_downloads_info(YtdlpArgs(), "https://example.com")
 
     assert result.payload == []

--- a/tests/anypod/ytdlp_wrapper/test_ytdlp_core.py
+++ b/tests/anypod/ytdlp_wrapper/test_ytdlp_core.py
@@ -43,7 +43,10 @@ async def test_extract_downloads_info_ignores_non_network_ytdlp_errors(
     mock_proc = MagicMock()
     mock_proc.returncode = 101
     mock_proc.communicate = AsyncMock(
-        return_value=(b"", b"ERROR: [youtube] abc123: Video unavailable. This video is private")
+        return_value=(
+            b"",
+            b"ERROR: [youtube] abc123: Video unavailable. This video is private",
+        )
     )
     mock_proc.wait = AsyncMock()
     mock_create_subprocess_exec.return_value = mock_proc


### PR DESCRIPTION
## Summary
- detect network-shaped yt-dlp metadata failures from stderr
- raise YtdlpApiError for those failures so feed sync is marked failed instead of advanced
- keep non-network yt-dlp errors ignored, including filtered/private playlist entries

## Tests
- uv run pytest tests/anypod/ytdlp_wrapper/test_ytdlp_core.py tests/anypod/ytdlp_wrapper/test_ytdlp_wrapper.py -q
- uv run ruff check src/anypod/ytdlp_wrapper/core/core.py tests/anypod/ytdlp_wrapper/test_ytdlp_core.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More precise detection of DNS resolution failures from yt-dlp; such failures now surface a clear "DNS resolution error" message and include combined logs for troubleshooting.
  * Non-network yt-dlp errors are still handled gracefully so normal operations continue when appropriate.

* **Tests**
  * Added and refined tests to validate DNS vs. non-network yt-dlp error handling and improve coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->